### PR TITLE
docs: add multi-team setup and security/RBAC guides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.0",
+        "pagefind": "^1.5.2",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
       }
@@ -1432,6 +1433,104 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -5969,6 +6068,25 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "node_modules/parse-latin": {
       "version": "7.0.0",

--- a/src/components/SearchButton.astro
+++ b/src/components/SearchButton.astro
@@ -1,0 +1,65 @@
+---
+// SearchButton — A trigger button for the search dialog.
+// Placed in the sidebar for discoverability.
+---
+
+<button class="search-trigger" id="search-trigger" aria-label="Search documentation">
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M10 10L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  </svg>
+  <span class="search-trigger-text">Search</span>
+  <kbd class="search-trigger-kbd">⌘K</kbd>
+</button>
+
+<style>
+  .search-trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 0.5rem;
+    background: var(--color-bg, #ffffff);
+    color: var(--color-text-tertiary, #9ca3af);
+    font-size: 0.8125rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, background-color 0.15s;
+    text-align: left;
+  }
+
+  .search-trigger:hover {
+    border-color: var(--color-accent, #3b82f6);
+    color: var(--color-text-secondary, #4a4a6a);
+    background: var(--color-bg-sidebar, #f9fafb);
+  }
+
+  .search-trigger-text {
+    flex: 1;
+  }
+
+  .search-trigger-kbd {
+    padding: 0.0625rem 0.3125rem;
+    font-size: 0.6875rem;
+    font-family: inherit;
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 0.25rem;
+    background: var(--color-bg-sidebar, #f9fafb);
+    line-height: 1.4;
+  }
+</style>
+
+<script>
+  document.getElementById('search-trigger')?.addEventListener('click', () => {
+    const dialog = document.getElementById('search-dialog');
+    const backdrop = document.getElementById('search-backdrop');
+    const input = document.getElementById('search-input') as HTMLInputElement;
+
+    dialog?.classList.add('is-open');
+    backdrop?.classList.add('is-open');
+    document.body.style.overflow = 'hidden';
+    input?.focus();
+  });
+</script>

--- a/src/content/docs/api-reference.md
+++ b/src/content/docs/api-reference.md
@@ -1,32 +1,1148 @@
 ---
 title: API Reference
-description: SWE-Squad REST API reference
+description: Complete API reference for SWE-Squad CLI, Dashboard, A2A protocol, and Webhooks
 section: API
 order: 1
 ---
 
 # API Reference
 
-The SWE-Squad API provides programmatic access to the platform.
+This page provides a complete API reference for all programmatic interfaces in SWE-Squad: the CLI commands, the Dashboard Data API, the Agent-to-Agent (A2A) protocol, and the Webhook Listener.
 
-## Authentication
+---
 
-All API requests require a bearer token:
+## 1. SWE-CLI Command Reference
+
+The `swe` command-line tool provides incident management, ticket operations, and reporting. All subcommands accept a `--format` flag to control output rendering.
+
+### Global Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | string | `table` | Output format. Accepted values: `table`, `json`, `csv`. |
+| `--team` | string | `$SWE_TEAM_ID` | Team ID to scope the operation. Overrides the `SWE_TEAM_ID` environment variable. |
+| `--no-color` | boolean | `false` | Disable colored output. Useful for piping or CI environments. |
+| `--help` | boolean | `false` | Show help text and exit. |
+
+---
+
+### `swe status`
+
+Show real-time system status including active agents, queue depth, and recent activity.
+
+**Syntax:**
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" https://api.swe-squad.dev/v1/tasks
+swe status [flags]
 ```
 
-## Endpoints
+**Flags:**
 
-### List Tasks
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--watch` | boolean | `false` | Continuously refresh status every 5 seconds. |
+| `--refresh-interval` | number | `5` | Refresh interval in seconds when `--watch` is set. |
 
-`GET /v1/tasks`
+**Example:**
 
-### Create Task
+```bash
+$ swe status
 
-`POST /v1/tasks`
+System Status: healthy
+Active Agents:    3  (explorer, planner, coder)
+Queue Depth:      2 tickets pending
+Uptime:           14h 23m
 
-### Get Task
+Recent Activity (last 10 minutes):
+  14:32:01  INC-042  fix.completed     Coder agent submitted patch
+  14:28:15  INC-042  fix.started       Planner selected strategy
+  14:25:40  INC-041  ticket.resolved   Fix merged to main
+  14:20:03  INC-043  ticket.created    DB connection timeout (critical)
+```
 
-`GET /v1/tasks/:id`
+**JSON output:**
+
+```bash
+$ swe status --format json
+```
+
+```json
+{
+  "status": "healthy",
+  "active_agents": ["explorer", "planner", "coder"],
+  "queue_depth": 2,
+  "uptime_seconds": 51780,
+  "recent_activity": [
+    {"timestamp": "2026-05-16T14:32:01Z", "ticket": "INC-042", "event": "fix.completed"},
+    {"timestamp": "2026-05-16T14:28:15Z", "ticket": "INC-042", "event": "fix.started"},
+    {"timestamp": "2026-05-16T14:25:40Z", "ticket": "INC-041", "event": "ticket.resolved"}
+  ]
+}
+```
+
+---
+
+### `swe tickets`
+
+List, inspect, create, and close tickets.
+
+**Syntax:**
+
+```bash
+swe tickets list   [flags]
+swe tickets show   <ticket-id> [flags]
+swe tickets create --title <title> --body <body> [flags]
+swe tickets close  <ticket-id> --reason <reason> [flags]
+```
+
+**Subcommands and Flags:**
+
+| Subcommand | Flags | Description |
+|------------|-------|-------------|
+| `list` | `--status`, `--severity`, `--limit`, `--sort` | List tickets with optional filters. |
+| `show` | *(positional: ticket-id)* | Display full ticket detail including fix history. |
+| `create` | `--title` (required), `--body` (required), `--severity` | Create a new ticket manually. |
+| `close` | `--reason` (required) | Close a ticket with a human-supplied reason. |
+
+**Filter flags for `list`:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--status` | string | *(all)* | Filter by status: `open`, `in_progress`, `resolved`, `closed`. |
+| `--severity` | string | *(all)* | Filter by severity: `critical`, `high`, `medium`, `low`. |
+| `--limit` | number | `20` | Maximum number of tickets to return. |
+| `--sort` | string | `created_desc` | Sort order. Accepted values: `created_desc`, `created_asc`, `severity`. |
+
+**Example:**
+
+```bash
+$ swe tickets list --severity critical --limit 5
+
+TICKET   TITLE                        SEVERITY   STATUS        CREATED
+INC-043  DB connection timeout         critical   open          3m ago
+INC-037  Payment gateway 502 errors    critical   in_progress   1h ago
+INC-029  Auth service crash loop       critical   resolved      1d ago
+```
+
+```bash
+$ swe tickets create \
+  --title "API latency spike on /v2/orders" \
+  --body "P99 latency exceeded 5s threshold starting at 14:00 UTC." \
+  --severity high
+
+Created ticket INC-044
+```
+
+```bash
+$ swe tickets show INC-043
+
+Ticket:     INC-043
+Title:      DB connection timeout
+Severity:   critical
+Status:     open
+Created:    2026-05-16 14:20:03 UTC
+Source:     prometheus alert
+
+Fix History:
+  (no fix attempts yet)
+
+Assigned Agents: (pending assignment)
+```
+
+---
+
+### `swe issues`
+
+Sync and browse GitHub issues linked to the configured repository.
+
+**Syntax:**
+
+```bash
+swe issues sync  [flags]
+swe issues list  [flags]
+swe issues show  <issue-number> [flags]
+```
+
+**Subcommands and Flags:**
+
+| Subcommand | Flags | Description |
+|------------|-------|-------------|
+| `sync` | `--full` | Fetch latest issues from GitHub. Use `--full` to re-sync entire issue history. |
+| `list` | `--labels`, `--state`, `--limit` | Browse locally cached issues with filters. |
+| `show` | *(positional: issue-number)* | Show issue body, comments, and linked ticket status. |
+
+**Filter flags for `list`:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--labels` | string | *(all)* | Comma-separated GitHub labels to filter on. Example: `bug,incident`. |
+| `--state` | string | `open` | Issue state: `open`, `closed`, `all`. |
+| `--limit` | number | `20` | Maximum issues to return. |
+
+**Example:**
+
+```bash
+$ swe issues sync
+Synced 14 issues from myorg/payment-service
+
+$ swe issues list --labels bug,incident --limit 10
+
+ISSUE   TITLE                         LABELS            STATE   LINKED TICKET
+#127    Memory leak in order worker    bug, incident     open    INC-043
+#124    Stale cache on product API     bug               open    (none)
+#119    Retry storm on DB failover     incident          closed  INC-037
+```
+
+---
+
+### `swe repos`
+
+Manage repository registrations for the current team.
+
+**Syntax:**
+
+```bash
+swe repos add     <repo-url> [flags]
+swe repos remove  <repo-url> [flags]
+swe repos list    [flags]
+```
+
+**Subcommands and Flags:**
+
+| Subcommand | Flags | Description |
+|------------|-------|-------------|
+| `add` | `--branch-prefix` | Register a repository for monitoring. Defaults to `swe-fix/`. |
+| `remove` | *(positional: repo-url)* | Unregister a repository. |
+| `list` | *(none)* | Show all registered repositories and their status. |
+
+**Example:**
+
+```bash
+$ swe repos add https://github.com/myorg/payment-service --branch-prefix fix/
+Registered myorg/payment-service (branch prefix: fix/)
+
+$ swe repos list
+
+REPOSITORY                           BRANCH PREFIX   STATUS   LAST SYNC
+myorg/payment-service                fix/            active   2m ago
+myorg/frontend-web                   swe-fix/        active   5m ago
+myorg/platform-core                  swe-fix/        active   1h ago
+```
+
+---
+
+### `swe summary`
+
+Generate summary reports for ticket activity, agent performance, and resolution trends.
+
+**Syntax:**
+
+```bash
+swe summary daily   [--date <YYYY-MM-DD>] [flags]
+swe summary weekly  [--week <YYYY-WNN>] [flags]
+swe summary agent   [--agent <name>] [--period <days>] [flags]
+```
+
+**Subcommands and Flags:**
+
+| Subcommand | Flags | Description |
+|------------|-------|-------------|
+| `daily` | `--date` | Daily summary. Defaults to today. |
+| `weekly` | `--week` | Weekly summary. Format: `2026-W20`. Defaults to current week. |
+| `agent` | `--agent`, `--period` | Agent performance breakdown. `--period` defaults to 7 days. |
+
+**Example:**
+
+```bash
+$ swe summary daily --date 2026-05-16
+
+Daily Summary — 2026-05-16
+
+Tickets Created:     8
+Tickets Resolved:    5
+Tickets In Progress: 3
+
+Mean Resolution Time:  23m 14s
+Median Resolution Time: 18m 02s
+
+Agent Invocations:
+  Explorer:  12 calls  (avg 4.1s)
+  Planner:    8 calls  (avg 11.3s)
+  Coder:      8 calls  (avg 34.7s)
+  Reviewer:   5 calls  (avg 18.2s)
+
+Stability Gate:
+  Passed: 5/5  (100%)
+  Rejected: 0
+```
+
+```bash
+$ swe summary agent --agent coder --period 14
+
+Agent Performance — coder (last 14 days)
+
+Total Invocations:   62
+Avg Response Time:   31.4s
+Success Rate:        91.9%  (57 pass / 5 fail)
+Avg Tokens Used:     4,218
+Total Token Cost:    $12.47
+
+Most Common Tools:
+  file_write   48 uses
+  file_read    62 uses
+  shell        31 uses
+  search       27 uses
+```
+
+---
+
+### `swe report`
+
+Export detailed reports in JSON, CSV, or Markdown format. Designed for scripting and integration with external tools.
+
+**Syntax:**
+
+```bash
+swe report --type <type> --from <date> --to <date> --format <format> [flags]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--type` | string | *(required)* | Report type: `tickets`, `agents`, `performance`, `full`. |
+| `--from` | string | *(required)* | Start date in `YYYY-MM-DD` format. |
+| `--to` | string | *(required)* | End date in `YYYY-MM-DD` format. |
+| `--format` | string | `json` | Output format: `json`, `csv`, `markdown`. |
+| `--output` | string | *(stdout)* | Write output to a file instead of stdout. |
+
+**Example:**
+
+```bash
+$ swe report \
+  --type tickets \
+  --from 2026-05-09 \
+  --to 2026-05-16 \
+  --format csv \
+  --output weekly-tickets.csv
+
+Exported 43 tickets to weekly-tickets.csv
+```
+
+```bash
+$ swe report --type performance --from 2026-05-01 --to 2026-05-16 --format json
+```
+
+```json
+{
+  "period": {"from": "2026-05-01", "to": "2026-05-16"},
+  "tickets": {"created": 87, "resolved": 74, "open": 13},
+  "resolution_time": {"mean_seconds": 1342, "median_seconds": 891},
+  "stability_gate": {"pass_rate": 0.946, "total_checks": 74, "passed": 70, "rejected": 4},
+  "agents": {
+    "explorer": {"invocations": 156, "avg_latency_ms": 4100},
+    "planner":  {"invocations": 98,  "avg_latency_ms": 11300},
+    "coder":    {"invocations": 98,  "avg_latency_ms": 34700},
+    "reviewer": {"invocations": 74,  "avg_latency_ms": 18200}
+  }
+}
+```
+
+---
+
+## 2. Dashboard Data API
+
+The SWE-Squad dashboard is backed by a Python-based API server (`dashboard_data.py`) that serves JSON endpoints for metrics, ticket data, and agent status. The server runs on the port specified by `SWE_DASHBOARD_PORT` (default `8080`).
+
+### Base URL and Authentication
+
+- **Base URL:** `http://localhost:<SWE_DASHBOARD_PORT>/api/dashboard`
+- **Authentication:** Bearer token via the `Authorization` header.
+
+```bash
+curl -H "Authorization: Bearer $SWE_DASHBOARD_TOKEN" \
+  http://localhost:8080/api/dashboard/overview
+```
+
+The dashboard token is auto-generated on startup and written to `$HOME/.swe-dashboard-token` unless `SWE_DASHBOARD_TOKEN` is set explicitly in the environment.
+
+---
+
+### `GET /api/dashboard/overview`
+
+Return system-level overview metrics.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `period` | string | `24h` | Aggregation window. Accepted values: `1h`, `24h`, `7d`, `30d`. |
+
+**Response Schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | System health status: `healthy`, `degraded`, `down`. |
+| `tickets_open` | number | Currently open tickets. |
+| `tickets_in_progress` | number | Tickets actively being worked on. |
+| `tickets_resolved_period` | number | Tickets resolved within the aggregation window. |
+| `mean_resolution_seconds` | number | Mean time to resolution in seconds. |
+| `active_agents` | array | List of currently running agent identifiers. |
+| `queue_depth` | number | Number of tickets waiting for agent assignment. |
+
+**Example:**
+
+```json
+{
+  "status": "healthy",
+  "tickets_open": 3,
+  "tickets_in_progress": 2,
+  "tickets_resolved_period": 14,
+  "mean_resolution_seconds": 892,
+  "active_agents": ["explorer", "coder", "reviewer"],
+  "queue_depth": 1
+}
+```
+
+---
+
+### `GET /api/dashboard/tickets`
+
+List tickets with filtering and pagination.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `status` | string | *(all)* | Filter by status: `open`, `in_progress`, `resolved`, `closed`. |
+| `severity` | string | *(all)* | Filter by severity: `critical`, `high`, `medium`, `low`. |
+| `limit` | number | `20` | Maximum results per page. |
+| `offset` | number | `0` | Pagination offset. |
+| `sort` | string | `created_desc` | Sort order: `created_desc`, `created_asc`, `severity`, `updated_desc`. |
+
+**Response Schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tickets` | array | Array of ticket objects. |
+| `tickets[].id` | string | Ticket identifier (e.g. `INC-043`). |
+| `tickets[].title` | string | Ticket title. |
+| `tickets[].severity` | string | Severity level. |
+| `tickets[].status` | string | Current status. |
+| `tickets[].created_at` | string | ISO 8601 timestamp. |
+| `tickets[].updated_at` | string | ISO 8601 timestamp. |
+| `tickets[].assigned_agent` | string or null | Currently assigned agent, if any. |
+| `total` | number | Total matching tickets (for pagination). |
+| `limit` | number | Applied limit. |
+| `offset` | number | Applied offset. |
+
+**Example:**
+
+```bash
+curl "http://localhost:8080/api/dashboard/tickets?severity=critical&limit=3"
+```
+
+```json
+{
+  "tickets": [
+    {
+      "id": "INC-043",
+      "title": "DB connection timeout",
+      "severity": "critical",
+      "status": "open",
+      "created_at": "2026-05-16T14:20:03Z",
+      "updated_at": "2026-05-16T14:20:03Z",
+      "assigned_agent": null
+    },
+    {
+      "id": "INC-037",
+      "title": "Payment gateway 502 errors",
+      "severity": "critical",
+      "status": "in_progress",
+      "created_at": "2026-05-16T13:01:44Z",
+      "updated_at": "2026-05-16T14:28:15Z",
+      "assigned_agent": "coder"
+    }
+  ],
+  "total": 2,
+  "limit": 3,
+  "offset": 0
+}
+```
+
+---
+
+### `GET /api/dashboard/tickets/:id`
+
+Retrieve full detail for a single ticket, including fix history and agent assignments.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Ticket identifier (e.g. `INC-043`). |
+
+**Response Schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Ticket identifier. |
+| `title` | string | Ticket title. |
+| `body` | string | Full ticket description. |
+| `severity` | string | Severity level. |
+| `status` | string | Current status. |
+| `source` | string | Origin of the ticket (e.g. `github`, `prometheus`, `manual`). |
+| `created_at` | string | ISO 8601 creation timestamp. |
+| `updated_at` | string | ISO 8601 last-update timestamp. |
+| `resolved_at` | string or null | ISO 8601 resolution timestamp, if resolved. |
+| `assigned_agents` | array | Ordered list of agents that have been assigned. |
+| `fix_history` | array | Array of fix attempt objects. |
+| `fix_history[].attempt` | number | Fix attempt number (1-indexed). |
+| `fix_history[].agent` | string | Agent that produced this fix. |
+| `fix_history[].status` | string | Result: `passed`, `failed`, `escalated`. |
+| `fix_history[].started_at` | string | ISO 8601 timestamp. |
+| `fix_history[].completed_at` | string | ISO 8601 timestamp. |
+| `fix_history[].failure_reason` | string or null | Reason for failure, if applicable. |
+| `stability_gate` | object or null | Gate results if a fix was validated. |
+| `stability_gate.passed` | boolean | Whether all stages passed. |
+| `stability_gate.stages` | array | Per-stage pass/fail results. |
+
+**Example:**
+
+```bash
+curl http://localhost:8080/api/dashboard/tickets/INC-041
+```
+
+```json
+{
+  "id": "INC-041",
+  "title": "Redis connection pool exhaustion",
+  "body": "Connection pool reached max capacity under sustained load...",
+  "severity": "high",
+  "status": "resolved",
+  "source": "prometheus",
+  "created_at": "2026-05-16T12:05:22Z",
+  "updated_at": "2026-05-16T14:25:40Z",
+  "resolved_at": "2026-05-16T14:25:40Z",
+  "assigned_agents": ["explorer", "planner", "coder", "reviewer"],
+  "fix_history": [
+    {
+      "attempt": 1,
+      "agent": "coder",
+      "status": "passed",
+      "started_at": "2026-05-16T14:10:00Z",
+      "completed_at": "2026-05-16T14:24:18Z",
+      "failure_reason": null
+    }
+  ],
+  "stability_gate": {
+    "passed": true,
+    "stages": [
+      {"name": "syntax_check", "passed": true},
+      {"name": "unit_tests", "passed": true},
+      {"name": "lint", "passed": true},
+      {"name": "type_check", "passed": true},
+      {"name": "security_scan", "passed": true},
+      {"name": "regression_test", "passed": true},
+      {"name": "scope_check", "passed": true},
+      {"name": "confidence_score", "passed": true, "score": 0.94}
+    ]
+  }
+}
+```
+
+---
+
+### `GET /api/dashboard/agents`
+
+Return status and recent invocation history for all agents.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `period` | string | `24h` | History window: `1h`, `24h`, `7d`, `30d`. |
+| `agent` | string | *(all)* | Filter to a specific agent name. |
+
+**Response Schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agents` | array | Array of agent status objects. |
+| `agents[].name` | string | Agent identifier (e.g. `explorer`). |
+| `agents[].status` | string | `idle`, `busy`, or `error`. |
+| `agents[].current_ticket` | string or null | Ticket the agent is currently working on. |
+| `agents[].invocations_period` | number | Total invocations in the period. |
+| `agents[].avg_latency_ms` | number | Average invocation latency. |
+| `agents[].success_rate` | number | Success rate as a decimal (0.0-1.0). |
+| `agents[].last_active` | string | ISO 8601 timestamp of last activity. |
+
+**Example:**
+
+```json
+{
+  "agents": [
+    {
+      "name": "explorer",
+      "status": "idle",
+      "current_ticket": null,
+      "invocations_period": 12,
+      "avg_latency_ms": 4100,
+      "success_rate": 1.0,
+      "last_active": "2026-05-16T14:25:40Z"
+    },
+    {
+      "name": "coder",
+      "status": "busy",
+      "current_ticket": "INC-042",
+      "invocations_period": 8,
+      "avg_latency_ms": 34700,
+      "success_rate": 0.875,
+      "last_active": "2026-05-16T14:32:01Z"
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/dashboard/metrics`
+
+Return aggregated performance metrics and resolution trends.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `period` | string | `7d` | Trend window: `1d`, `7d`, `30d`. |
+| `granularity` | string | `1h` | Data point spacing: `1h`, `6h`, `1d`. |
+
+**Response Schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `period` | string | Requested period. |
+| `resolution_time` | object | Resolution time statistics. |
+| `resolution_time.mean_seconds` | number | Mean time to resolution. |
+| `resolution_time.median_seconds` | number | Median time to resolution. |
+| `resolution_time.p95_seconds` | number | 95th percentile resolution time. |
+| `throughput` | object | Ticket throughput counts. |
+| `throughput.created` | number | Tickets created in the period. |
+| `throughput.resolved` | number | Tickets resolved in the period. |
+| `throughput.escalated` | number | Tickets escalated to humans. |
+| `stability_gate_pass_rate` | number | Overall gate pass rate (0.0-1.0). |
+| `trend` | array | Time-series data points. Each entry has `timestamp`, `tickets_created`, `tickets_resolved`, `avg_resolution_seconds`. |
+
+**Example:**
+
+```json
+{
+  "period": "7d",
+  "resolution_time": {
+    "mean_seconds": 1342,
+    "median_seconds": 891,
+    "p95_seconds": 3420
+  },
+  "throughput": {
+    "created": 87,
+    "resolved": 74,
+    "escalated": 4
+  },
+  "stability_gate_pass_rate": 0.946,
+  "trend": [
+    {"timestamp": "2026-05-09T00:00:00Z", "tickets_created": 11, "tickets_resolved": 9, "avg_resolution_seconds": 1210},
+    {"timestamp": "2026-05-10T00:00:00Z", "tickets_created": 14, "tickets_resolved": 12, "avg_resolution_seconds": 980}
+  ]
+}
+```
+
+---
+
+### `GET /api/dashboard/activity`
+
+Return a reverse-chronological feed of recent system events.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | number | `50` | Maximum events to return. |
+| `ticket` | string | *(all)* | Filter events to a specific ticket ID. |
+| `event_type` | string | *(all)* | Filter by event type (e.g. `fix.completed`). |
+
+**Response Schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `events` | array | Array of event objects. |
+| `events[].id` | string | Unique event identifier. |
+| `events[].timestamp` | string | ISO 8601 timestamp. |
+| `events[].event_type` | string | Event type (see A2A event types). |
+| `events[].ticket_id` | string | Associated ticket. |
+| `events[].agent` | string or null | Agent that triggered the event. |
+| `events[].details` | object | Event-specific metadata. |
+
+**Example:**
+
+```json
+{
+  "events": [
+    {
+      "id": "evt-8a2f",
+      "timestamp": "2026-05-16T14:32:01Z",
+      "event_type": "fix.completed",
+      "ticket_id": "INC-042",
+      "agent": "coder",
+      "details": {"files_changed": 3, "lines_added": 47, "lines_removed": 12}
+    },
+    {
+      "id": "evt-7b1e",
+      "timestamp": "2026-05-16T14:28:15Z",
+      "event_type": "fix.started",
+      "ticket_id": "INC-042",
+      "agent": "coder",
+      "details": {"strategy": "increase_pool_size"}
+    }
+  ]
+}
+```
+
+---
+
+## 3. A2A Protocol Reference
+
+The Agent-to-Agent (A2A) protocol governs communication between specialized SWE-Squad agents (Explorer, Planner, Coder, Reviewer) and the central hub. It uses JSON-RPC 2.0 as the message format.
+
+### JSON-RPC 2.0 Message Format
+
+All A2A messages follow the JSON-RPC 2.0 specification with three patterns:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "ticket.assign",
+  "params": {"ticket_id": "INC-043", "agent": "explorer"},
+  "id": 1
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {"status": "assigned", "ticket_id": "INC-043"},
+  "id": 1
+}
+```
+
+**Notification (no response expected):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "event.emit",
+  "params": {"event_type": "fix.started", "ticket_id": "INC-043"}
+}
+```
+
+**Error Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {"code": -32600, "message": "Invalid params: missing ticket_id"},
+  "id": 1
+}
+```
+
+Standard error codes: `-32700` (parse error), `-32600` (invalid request), `-32601` (method not found), `-32602` (invalid params), `-32603` (internal error).
+
+---
+
+### Event Types
+
+Events represent state transitions in the ticket lifecycle. Each event carries a typed payload.
+
+| Event Type | Trigger | Payload Fields |
+|------------|---------|----------------|
+| `ticket.created` | New ticket enters the system | `ticket_id`, `title`, `severity`, `source` |
+| `ticket.assigned` | Agent is assigned to a ticket | `ticket_id`, `agent`, `assigned_by` |
+| `fix.started` | Agent begins generating a fix | `ticket_id`, `agent`, `strategy` |
+| `fix.completed` | Agent submits a proposed fix | `ticket_id`, `agent`, `files_changed`, `lines_added`, `lines_removed` |
+| `review.requested` | Fix is sent to the reviewer agent | `ticket_id`, `reviewer`, `fix_attempt` |
+| `review.completed` | Reviewer finishes evaluating a fix | `ticket_id`, `reviewer`, `approved`, `issues` |
+| `ticket.resolved` | Ticket is fully resolved and closed | `ticket_id`, `resolved_by`, `merge_sha` |
+
+**Example event payloads:**
+
+```json
+{
+  "event_type": "ticket.created",
+  "ticket_id": "INC-043",
+  "title": "DB connection timeout",
+  "severity": "critical",
+  "source": "prometheus",
+  "timestamp": "2026-05-16T14:20:03Z"
+}
+```
+
+```json
+{
+  "event_type": "fix.completed",
+  "ticket_id": "INC-042",
+  "agent": "coder",
+  "files_changed": 3,
+  "lines_added": 47,
+  "lines_removed": 12,
+  "timestamp": "2026-05-16T14:32:01Z"
+}
+```
+
+```json
+{
+  "event_type": "review.completed",
+  "ticket_id": "INC-042",
+  "reviewer": "reviewer",
+  "approved": true,
+  "issues": [],
+  "timestamp": "2026-05-16T14:35:18Z"
+}
+```
+
+```json
+{
+  "event_type": "ticket.resolved",
+  "ticket_id": "INC-041",
+  "resolved_by": "auto",
+  "merge_sha": "a1b2c3d4e5f6",
+  "timestamp": "2026-05-16T14:25:40Z"
+}
+```
+
+---
+
+### Agent Card Schema
+
+Each agent publishes a card describing its capabilities, endpoints, and authentication requirements. Cards are used for agent discovery and registration.
+
+**Schema:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_id` | string | Unique agent identifier (e.g. `explorer`, `coder`). |
+| `name` | string | Human-readable agent name. |
+| `version` | string | Agent version string. |
+| `description` | string | Short description of agent capabilities. |
+| `capabilities` | array | List of capability strings (e.g. `file_read`, `search`, `shell`). |
+| `endpoint` | string | URL where the agent accepts JSON-RPC requests. |
+| `authentication` | object | Auth configuration for the agent endpoint. |
+| `authentication.type` | string | Auth method: `bearer`, `api_key`, or `none`. |
+| `authentication.header` | string | Header name for the auth token (e.g. `Authorization`). |
+| `metadata` | object | Additional key-value metadata. |
+
+**Example agent card:**
+
+```json
+{
+  "agent_id": "coder",
+  "name": "Coder Agent",
+  "version": "2.1.0",
+  "description": "Implements code changes based on planned fix strategies.",
+  "capabilities": ["file_read", "file_write", "shell", "search", "test_runner"],
+  "endpoint": "http://localhost:8081/a2a/agents/coder",
+  "authentication": {
+    "type": "bearer",
+    "header": "Authorization"
+  },
+  "metadata": {
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.2,
+    "max_tokens": 8192
+  }
+}
+```
+
+---
+
+### Hub API Endpoints
+
+The A2A hub coordinates agent communication and event dispatch.
+
+#### `POST /a2a/dispatch`
+
+Dispatch a task or message to a specific agent.
+
+**Request Body:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `jsonrpc` | string | Must be `"2.0"`. |
+| `method` | string | Method to invoke on the target agent. |
+| `params` | object | Method parameters. |
+| `target` | string | Target agent identifier. |
+
+**Example:**
+
+```bash
+curl -X POST http://localhost:8080/a2a/dispatch \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "investigate",
+    "params": {"ticket_id": "INC-043", "context": {"repository": "myorg/payment-service"}},
+    "target": "explorer",
+    "id": 42
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "status": "accepted",
+    "task_id": "task-9e4a",
+    "agent": "explorer"
+  },
+  "id": 42
+}
+```
+
+#### `GET /a2a/agents/:id/card`
+
+Retrieve the agent card for a registered agent.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Agent identifier. |
+
+**Example:**
+
+```bash
+curl http://localhost:8080/a2a/agents/coder/card \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Returns the agent card JSON object (see Agent Card Schema above).
+
+#### `GET /a2a/events`
+
+Stream or poll recent A2A events.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `since` | string | *(all)* | ISO 8601 timestamp. Only return events after this time. |
+| `event_type` | string | *(all)* | Filter to a specific event type. |
+| `ticket_id` | string | *(all)* | Filter to events for a specific ticket. |
+| `limit` | number | `100` | Maximum events to return. |
+
+**Example:**
+
+```bash
+curl "http://localhost:8080/a2a/events?since=2026-05-16T14:00:00Z&limit=10" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "events": [
+    {
+      "id": "evt-8a2f",
+      "event_type": "fix.completed",
+      "ticket_id": "INC-042",
+      "agent": "coder",
+      "timestamp": "2026-05-16T14:32:01Z",
+      "payload": {"files_changed": 3, "lines_added": 47, "lines_removed": 12}
+    }
+  ],
+  "has_more": true,
+  "next_cursor": "evt-8a2f"
+}
+```
+
+#### `POST /a2a/events/:id/ack`
+
+Acknowledge that an event has been processed. Required for events that require explicit confirmation.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Event identifier to acknowledge. |
+
+**Request Body:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | `"processed"` or `"failed"`. |
+| `details` | object | Optional metadata about the processing result. |
+
+**Example:**
+
+```bash
+curl -X POST http://localhost:8080/a2a/events/evt-8a2f/ack \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "processed", "details": {"reviewer": "reviewer", "approved": true}}'
+```
+
+**Response:**
+
+```json
+{
+  "acknowledged": true,
+  "event_id": "evt-8a2f",
+  "timestamp": "2026-05-16T14:36:00Z"
+}
+```
+
+---
+
+## 4. Webhook Listener API
+
+SWE-Squad can receive incoming webhooks from GitHub to trigger incident creation on push, issue, and pull request events. Webhooks are validated using HMAC signatures.
+
+### `POST /webhooks/github`
+
+The primary endpoint for receiving GitHub webhook deliveries.
+
+**Authentication:**
+
+Every request is validated against the `X-Hub-Signature-256` header using HMAC-SHA256 with the `SWE_WEBHOOK_SECRET` configured in your environment.
+
+```
+X-Hub-Signature-256: sha256=<hex-digest>
+```
+
+Validation steps:
+1. Read the raw request body.
+2. Compute `HMAC-SHA256(raw_body, SWE_WEBHOOK_SECRET)`.
+3. Compare the hex digest to the value in the `X-Hub-Signature-256` header using a constant-time comparison.
+4. Reject with `401` if the signatures do not match.
+
+### Response Codes
+
+| Code | Meaning | Description |
+|------|---------|-------------|
+| `200` | Accepted | Payload validated and queued for processing. |
+| `401` | Unauthorized | Invalid or missing HMAC signature. |
+| `400` | Bad Request | Payload could not be parsed or is missing required fields. |
+
+### Supported Event Types
+
+The webhook listener handles the following GitHub event types, determined by the `X-GitHub-Event` header:
+
+| `X-GitHub-Event` | Trigger |
+|-------------------|---------|
+| `push` | Code pushed to any branch. |
+| `issues` | Issue opened, edited, closed, or reopened. |
+| `pull_request` | PR opened, closed, merged, or synchronized. |
+
+### Payload Schemas
+
+#### Push Event
+
+```json
+{
+  "ref": "refs/heads/main",
+  "before": "a1b2c3d4e5f6",
+  "after": "f6e5d4c3b2a1",
+  "repository": {
+    "full_name": "myorg/payment-service",
+    "html_url": "https://github.com/myorg/payment-service"
+  },
+  "sender": {
+    "login": "ci-bot"
+  },
+  "commits": [
+    {
+      "id": "f6e5d4c3b2a1",
+      "message": "fix: increase connection pool size",
+      "author": {"name": "SWE-Squad Coder Agent"},
+      "added": [],
+      "removed": [],
+      "modified": ["src/db/pool.py", "src/config.py", "tests/test_pool.py"]
+    }
+  ]
+}
+```
+
+#### Issues Event
+
+```json
+{
+  "action": "opened",
+  "issue": {
+    "number": 127,
+    "title": "Memory leak in order worker",
+    "body": "The order worker process grows to 4GB RSS under sustained load...",
+    "state": "open",
+    "labels": [{"name": "bug"}, {"name": "incident"}],
+    "created_at": "2026-05-16T14:45:00Z"
+  },
+  "repository": {
+    "full_name": "myorg/payment-service"
+  },
+  "sender": {
+    "login": "oncall-engineer"
+  }
+}
+```
+
+#### Pull Request Event
+
+```json
+{
+  "action": "closed",
+  "pull_request": {
+    "number": 84,
+    "title": "fix: resolve Redis connection pool exhaustion (INC-041)",
+    "body": "Automated fix generated by SWE-Squad Coder Agent.\n\nIncreases pool max size and adds idle timeout.",
+    "state": "closed",
+    "merged": true,
+    "merge_commit_sha": "a1b2c3d4e5f6",
+    "base": {"ref": "main"},
+    "head": {"ref": "swe-fix/ticket-inc041"}
+  },
+  "repository": {
+    "full_name": "myorg/payment-service"
+  },
+  "sender": {
+    "login": "swe-squad-bot"
+  }
+}
+```
+
+### Retry Behavior
+
+When the webhook listener returns a non-200 response, the caller should retry delivery with the following policy:
+
+| Attempt | Delay |
+|---------|-------|
+| 1st retry | 5 seconds |
+| 2nd retry | 25 seconds |
+| 3rd retry | 125 seconds |
+
+After 3 failed attempts (4 total deliveries), the webhook is logged as permanently failed and an alert is emitted to the configured notification channels. Retries use exponential backoff with a base of 5 seconds.
+
+### Example: Validating a Webhook in Python
+
+```python
+import hmac
+import hashlib
+
+def validate_signature(payload: bytes, signature: str, secret: str) -> bool:
+    expected = "sha256=" + hmac.new(
+        secret.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```

--- a/src/content/docs/multi-team-setup.md
+++ b/src/content/docs/multi-team-setup.md
@@ -1,0 +1,262 @@
+---
+title: Multi-Team Setup
+description: Configure multiple squads with separate team IDs, dedicated GitHub bots, shared Supabase, ticket isolation, and cross-team semantic memory
+section: Advanced
+order: 2
+---
+
+# Multi-Team Setup
+
+SWE-Squad supports multiple engineering teams operating within a single organization. Each team gets its own isolated workspace with independent model preferences, governance rules, and codebase scope boundaries, while all teams share a common semantic memory store for cross-team learning.
+
+## Overview
+
+In a multi-team deployment, every squad operates as an independent unit with its own configuration, agent tuning, and escalation policies. A backend team handling Go microservices can run with strict governance and manual approval, while a frontend team shipping TypeScript may prefer auto-merge and faster polling intervals. Despite this isolation, the shared memory store ensures that lessons learned by one team benefit others encountering similar patterns.
+
+The key primitives that make multi-team support work are:
+
+- **Team Router** -- Directs incoming alerts to the correct team based on service ownership metadata.
+- **SWE_TEAM_ID** -- A unique identifier that namespaces all ticket state, branch names, and persisted data per team.
+- **Scoped Codebase Access** -- Agents operate within strictly defined file paths, preventing cross-team changes.
+- **Shared Supabase Backend** -- All teams write to the same Supabase instance, with isolation enforced by `SWE_TEAM_ID`.
+- **Dedicated GitHub Bots** -- Each team uses its own GitHub token and bot account for correct attribution and scope control.
+- **Cross-Team Semantic Memory** -- Knowledge accumulated by any team is available to all teams through the shared memory store.
+
+## Architecture
+
+The following diagram illustrates how multiple teams route through a shared platform while maintaining scoped codebase access and a common memory store:
+
+```mermaid
+flowchart TD
+    subgraph MultiTeam["Multi-Team Scoping"]
+        Router[Team Router]
+        Memory[Shared Memory Store]
+        Router --> TeamA["Team Alpha<br/>Backend Services"]
+        Router --> TeamB["Team Bravo<br/>Frontend & Mobile"]
+        Router --> TeamC["Team Charlie<br/>Data Pipeline"]
+        TeamA --> ScopeA["Scoped Codebase Access<br/>Service A, B, C"]
+        TeamB --> ScopeB["Scoped Codebase Access<br/>Web, iOS, Android"]
+        TeamC --> ScopeC["Scoped Codebase Access<br/>ETL, ML Pipeline"]
+        ScopeA --> Memory
+        ScopeB --> Memory
+        ScopeC --> Memory
+    end
+```
+
+Each team receives alerts from the Team Router, operates within its own scoped codebase, and writes findings back to the shared memory store. The memory store is the single integration point across teams -- no team directly accesses another team's codebase or ticket state.
+
+## Team Router
+
+The Team Router is the entry point for all incoming alerts. It reads service ownership metadata attached to each alert and directs it to the correct team. This metadata typically comes from monitoring sources (PagerDuty, Datadog, GitHub) and includes the service name, repository, or error category.
+
+Routing logic works as follows:
+
+1. An alert arrives with metadata identifying the source service (for example, `backend-api`, `frontend-web`, or `data-pipeline`).
+2. The Team Router matches the service against the configured team scopes in `swe_team.yaml`.
+3. The alert is dispatched to the matching team's pipeline. If no match is found, the alert is routed to a default team or flagged for manual triage.
+4. When an alert spans multiple services owned by different teams, the Router broadcasts it to all affected teams simultaneously (see [Cross-Team Incidents](#cross-team-incidents)).
+
+This ensures that a backend timeout alert is handled by the backend team with the right model configuration and governance rules, while a frontend rendering error goes to the frontend team with its own settings.
+
+## Configuring Teams
+
+Each team requires two configuration files: a `swe_team.yaml` for structural and behavioral settings, and a `.env` file for secrets and runtime toggles. The following examples demonstrate a two-team setup sharing a single Supabase instance.
+
+### Team A: backend-api
+
+**swe_team.yaml:**
+
+```yaml
+version: 1
+
+project:
+  name: backend-api
+  language: go
+  repository: https://github.com/myorg/backend-api
+  branch_prefix: swe-fix/backend-api/
+
+monitor:
+  sources:
+    - github
+    - pagerduty
+  severity_filter:
+    - critical
+    - high
+  labels:
+    - incident
+
+governance:
+  require_approval: true
+  auto_merge: false
+  stability_gate: true
+  test_threshold: 0.85
+  rejection_limit: 2
+
+agents:
+  coder:
+    max_tokens: 8192
+    timeout: 240
+
+integrations:
+  pagerduty:
+    api_key: pd-api-key-team-a
+  slack:
+    webhook_url: https://hooks.slack.com/services/T00/B00/team-a
+```
+
+**.env:**
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+GITHUB_TOKEN=ghp_...
+SUPABASE_URL=https://shared.supabase.co
+SUPABASE_ANON_KEY=eyJ...
+SWE_TEAM_ID=backend-api-team
+```
+
+Team A is configured for a Go backend service with strict governance: every PR requires manual approval, auto-merge is disabled, and the test threshold is set to 85%. The coder agent has an extended timeout of 240 seconds to accommodate longer compilation cycles.
+
+### Team B: frontend-web
+
+**swe_team.yaml:**
+
+```yaml
+version: 1
+
+project:
+  name: frontend-web
+  language: typescript
+  repository: https://github.com/myorg/frontend-web
+  branch_prefix: swe-fix/frontend-web/
+
+monitor:
+  sources:
+    - github
+    - datadog
+  poll_interval: 20
+  severity_filter:
+    - critical
+    - high
+    - medium
+
+governance:
+  require_approval: false
+  auto_merge: true
+  stability_gate: true
+  test_threshold: 0.8
+  max_file_changes: 25
+
+agents:
+  explorer:
+    max_tokens: 4096
+  reviewer:
+    model: opus
+    max_tokens: 8192
+
+integrations:
+  datadog:
+    api_key: dd-api-key-team-b
+    app_key: dd-app-key-team-b
+  slack:
+    webhook_url: https://hooks.slack.com/services/T00/B00/team-b
+```
+
+**.env:**
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+GITHUB_TOKEN=ghp_...
+SUPABASE_URL=https://shared.supabase.co
+SUPABASE_ANON_KEY=eyJ...
+SWE_TEAM_ID=frontend-web-team
+```
+
+Team B operates a TypeScript frontend with lighter governance: auto-merge is enabled, approval is not required, and the severity filter includes medium-priority issues. The reviewer agent is upgraded to Opus for thorough code review of UI changes.
+
+## Shared Supabase Backend
+
+All teams in a multi-team deployment write to the same Supabase instance. The `SUPABASE_URL` and `SUPABASE_ANON_KEY` are identical across teams, while the `SWE_TEAM_ID` differentiates each team's data:
+
+| Variable | Team A | Team B |
+|----------|--------|--------|
+| `SUPABASE_URL` | `https://shared.supabase.co` | `https://shared.supabase.co` |
+| `SUPABASE_ANON_KEY` | `eyJ...` | `eyJ...` |
+| `SWE_TEAM_ID` | `backend-api-team` | `frontend-web-team` |
+
+This shared backend simplifies infrastructure management -- you provision and maintain a single Supabase project rather than one per team. The database schema uses `SWE_TEAM_ID` as a partition key on all ticket and state tables, so queries are automatically scoped to the requesting team.
+
+## Ticket Isolation
+
+The `SWE_TEAM_ID` environment variable is the primary isolation mechanism between teams. Every ticket, branch, and persisted state entry is namespaced with this identifier:
+
+- **Ticket queries** include a `WHERE team_id = ?` filter, so each team only sees and operates on its own tickets.
+- **Branch names** are prefixed with the team's `branch_prefix` (for example, `swe-fix/backend-api/ticket-abc123`), preventing naming collisions.
+- **State transitions** (New, Triaged, Investigating, In Development, In Review, Deployed) are tracked per team, so one team's pipeline never interferes with another's.
+
+This means Team Alpha can have a ticket in the In Review state while Team Bravo processes a separate ticket through Triage, and neither team's operations affect the other's state.
+
+## Dedicated GitHub Bot Accounts
+
+Each team should use its own GitHub bot account and personal access token. This provides three benefits:
+
+1. **Correct attribution** -- PRs and comments show the team's bot identity rather than a shared generic account, making it clear which team's automation created a change.
+2. **Scope isolation** -- Each token is scoped to only the repositories that team manages, preventing accidental access to another team's codebase.
+3. **Rate limit independence** -- Each token has its own API rate limit budget, so a high-activity team does not throttle another team's automation.
+
+Configuration is straightforward. Each team sets its own `GITHUB_TOKEN` in its `.env` file:
+
+```bash
+# Team A .env
+GITHUB_TOKEN=ghp_backend-bot-token
+
+# Team B .env
+GITHUB_TOKEN=ghp_frontend-bot-token
+```
+
+When creating the bot accounts, restrict each token's scope to the repositories owned by that team. For example, the backend bot token should only have access to `myorg/backend-api` and related service repos, while the frontend bot token should only access `myorg/frontend-web` and its dependencies.
+
+## Scoped Codebase Access
+
+Within each team, agents operate within strictly scoped codebase boundaries defined by the `scope` configuration. A backend agent cannot access frontend repositories and vice versa. This prevents accidental cross-team changes and keeps each team's context window focused on relevant code.
+
+Define scopes in the `teams` section of your configuration:
+
+```yaml
+teams:
+  - name: platform
+    models: { triage: haiku, fix: sonnet }
+    scope: ["src/core", "src/api"]
+  - name: frontend
+    models: { triage: haiku, fix: haiku }
+    scope: ["src/web", "src/components"]
+```
+
+In this example, the platform team's agents can only read and modify files under `src/core` and `src/api`. The frontend team's agents are restricted to `src/web` and `src/components`. Any file path outside the configured scope is inaccessible to that team's agents.
+
+Scope enforcement applies at the file-read and file-write level. An agent that attempts to read a file outside its scope receives an access-denied response, and write attempts to out-of-scope paths are rejected before execution. This is a hard boundary -- there is no override or bypass mechanism.
+
+## Cross-Team Semantic Memory
+
+Despite scoped codebases, the semantic memory store is shared across all teams. When one team resolves a novel issue, the Distiller Agent extracts the key findings and writes them to the shared memory. Any team that later encounters a similar pattern can retrieve that knowledge, even if the original issue was in a different service or language.
+
+This creates a compounding knowledge effect:
+
+- A backend team's fix for a database connection leak teaches the data pipeline team about connection pooling patterns.
+- A frontend team's resolution of a race condition informs the mobile team about async state management.
+- Over time, the shared memory reduces duplicate investigations across the organization.
+
+The memory store uses semantic similarity matching, not exact string matching. This means lessons are transferred based on conceptual similarity rather than identical error messages, making cross-team knowledge transfer effective even when teams use different languages, frameworks, or error formats.
+
+## Cross-Team Incidents
+
+Some incidents span multiple teams. A common example is an API change in a backend service that breaks a frontend consumer. The Team Router handles these cases by detecting overlap in the alert's affected services and broadcasting the incident to all relevant teams simultaneously.
+
+The cross-team incident flow works as follows:
+
+1. The Team Router receives an alert that references services owned by multiple teams (for example, both `backend-api` and `frontend-web`).
+2. The Router creates a separate ticket in each affected team's namespace, linked by a shared incident correlation ID.
+3. Each team investigates the incident within its own scoped codebase, using its own model configuration and governance rules.
+4. As each team posts findings to the shared memory store, other teams working the same incident can access the accumulated context.
+5. When one team's fix resolves the root cause, the correlated tickets in other teams are automatically updated with the resolution context, allowing them to verify the fix on their side.
+
+This broadcast-and-correlate approach ensures that cross-team incidents are handled in parallel rather than sequentially. The frontend team does not wait for the backend team to finish before starting its investigation -- both work concurrently, sharing context through the memory store as they go.

--- a/src/content/docs/provider-plugin-guide.md
+++ b/src/content/docs/provider-plugin-guide.md
@@ -1,0 +1,1633 @@
+---
+title: "Provider Plugin Development Guide"
+description: "Build custom provider plugins for SWE-Squad's provider-agnostic architecture"
+section: "Advanced"
+order: 1
+---
+
+# Provider Plugin Development Guide
+
+This guide explains how to build custom provider plugins for SWE-Squad's provider-agnostic architecture. It covers the core design philosophy, all seven provider interfaces, a step-by-step tutorial for building a Slack notification provider, YAML registration, and testing patterns.
+
+See also: [Configuration Reference](/docs/configuration-reference) for the full `swe_team.yaml` schema and environment variable documentation. See also: [Architecture](/architecture) for the high-level provider plugin architecture diagram.
+
+---
+
+## 1. Provider-Agnostic Architecture Philosophy
+
+SWE-Squad is built on a single guiding principle: **if it can be replaced by a competitor, it must be behind an interface.** Every external dependency in the system -- from the LLM backend to the notification channel to the vector database -- is isolated behind an abstract Python class. The core pipeline never imports or references a concrete implementation directly. Instead, it depends entirely on abstract interfaces and resolves concrete implementations at runtime through a central registry.
+
+This design has three practical consequences:
+
+- **Zero lock-in.** Swapping Anthropic for OpenAI, Pinecone for Weaviate, or Slack for Discord requires a single configuration change, not a code change. The pipeline code is identical regardless of which concrete provider is active.
+- **Hybrid deployments.** Different providers can handle different stages simultaneously. A team can use Anthropic for investigation, OpenAI for triage, a local model server for embedding, and Redis for task queuing -- all in the same pipeline run.
+- **Custom extensions.** Any team can write a provider plugin for an internal or niche service and register it alongside the built-in implementations. No fork required.
+
+### BaseProvider and ProviderRegistry
+
+Every provider interface in SWE-Squad inherits from a common `BaseProvider` abstract class. At a minimum, `BaseProvider` defines the lifecycle contract that all providers must satisfy:
+
+```python
+from abc import ABC, abstractmethod
+
+class BaseProvider(ABC):
+    """Base class for all SWE-Squad provider plugins."""
+
+    @abstractmethod
+    async def initialize(self, config: dict) -> None:
+        """Called once after construction to pass runtime configuration."""
+        ...
+
+    @abstractmethod
+    async def shutdown(self) -> None:
+        """Called during graceful shutdown to release resources."""
+        ...
+
+    @abstractmethod
+    def health_check(self) -> bool:
+        """Return True if the provider is operational."""
+        ...
+```
+
+Concrete providers extend `BaseProvider` and implement the domain-specific abstract methods for their interface type (for example, `complete` and `embed` for `CodingEngine`).
+
+The `ProviderRegistry` is a singleton that manages provider registration and lookup. It is populated at startup from the `swe_team.yaml` configuration file and can be extended programmatically:
+
+```python
+from swe_team.providers import ProviderRegistry
+
+# The registry is populated automatically from swe_team.yaml at startup.
+# You can also register providers programmatically:
+
+registry = ProviderRegistry.instance()
+registry.register("notifications", "slack", SlackNotificationProvider(
+    bot_token="xoxb-...",
+    default_channel="#alerts"
+))
+
+# Lookup by interface type and provider name
+provider = registry.get("notifications", "slack")
+```
+
+### Provider Registry Pattern
+
+The following diagram shows how the registry connects the pipeline to concrete implementations at runtime:
+
+```mermaid
+flowchart TD
+    subgraph Pipeline["SWE-Squad Pipeline"]
+        A1[Explorer Agent]
+        A2[Planner Agent]
+        A3[Coder Agent]
+        A4[Reviewer Agent]
+    end
+
+    subgraph Registry["ProviderRegistry"]
+        R1[notifications: slack]
+        R2[coding: anthropic]
+        R3[issues: github]
+        R4[sandbox: docker]
+        R5[embedding: openai]
+        R6[vectorstore: pinecone]
+        R7[taskqueue: redis]
+    end
+
+    subgraph Interfaces["Abstract Interfaces"]
+        I1[NotificationProvider]
+        I2[CodingEngine]
+        I3[IssueTracker]
+        I4[SandboxProvider]
+        I5[EmbeddingProvider]
+        I6[VectorStore]
+        I7[TaskQueueProvider]
+    end
+
+    Pipeline -->|"depends on"| Interfaces
+    Interfaces -->|"resolved by"| Registry
+
+    subgraph Implementations["Concrete Implementations"]
+        C1[SlackNotificationProvider]
+        C2[AnthropicProvider]
+        C3[GitHubIssueTracker]
+        C4[DockerSandboxProvider]
+        C5[OpenAIEmbeddingProvider]
+        C6[PineconeVectorStore]
+        C7[RedisTaskQueue]
+    end
+
+    Registry -->|"instantiates"| Implementations
+```
+
+When an agent needs to send a notification, it asks the registry for the current `NotificationProvider`. The registry returns the concrete instance that was registered under that interface type, and the agent calls its methods without knowing or caring which implementation is active.
+
+---
+
+## 2. Interface Definitions for Each Provider Type
+
+SWE-Squad defines seven provider interfaces. Each interface is an abstract class with a fixed set of methods that concrete providers must implement. This section documents every interface, its methods, and the built-in implementations that ship with SWE-Squad.
+
+### 2.1 CodingEngine
+
+The `CodingEngine` interface wraps the large language model backend. All agent invocations -- exploration, planning, code generation, and review -- go through this interface.
+
+```python
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+
+class CodingEngine(BaseProvider):
+    """Abstract interface for LLM completion and embedding backends."""
+
+    @abstractmethod
+    async def complete(self, prompt: str, **kwargs) -> str:
+        """Generate a completion for the given prompt.
+
+        Args:
+            prompt: The input prompt string.
+            **kwargs: Optional overrides for model, temperature, max_tokens, etc.
+
+        Returns:
+            The generated completion text.
+        """
+        ...
+
+    @abstractmethod
+    async def embed(self, text: str) -> list[float]:
+        """Generate an embedding vector for the given text.
+
+        Args:
+            text: The input text to embed.
+
+        Returns:
+            A list of floats representing the embedding vector.
+        """
+        ...
+
+    @abstractmethod
+    async def stream(self, prompt: str, **kwargs) -> AsyncIterator[str]:
+        """Stream a completion token by token.
+
+        Args:
+            prompt: The input prompt string.
+            **kwargs: Optional overrides for model, temperature, max_tokens, etc.
+
+        Yields:
+            Individual tokens as they are generated.
+        """
+        ...
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `complete(prompt, **kwargs)` | `str` | Generate a full completion for the prompt. Accepts optional `model`, `temperature`, `max_tokens`, and `system` keyword arguments. |
+| `embed(text)` | `list[float]` | Generate a dense embedding vector for the input text. Used by the semantic memory system. |
+| `stream(prompt, **kwargs)` | `AsyncIterator[str]` | Stream a completion token by token. Used for real-time dashboard display and interactive CLI sessions. |
+
+**Built-in implementations:**
+
+| Implementation | Description |
+|---------------|-------------|
+| `AnthropicProvider` | Default provider. Connects to the Anthropic API using the `ANTHROPIC_API_KEY` environment variable. Supports Claude Haiku, Sonnet, and Opus models. |
+| `OpenAIProvider` | Connects to the OpenAI API using the `OPENAI_API_KEY` environment variable. Supports GPT-4o, GPT-4o-mini, and compatible endpoints. |
+| `LocalProvider` | Connects to a local model server via an OpenAI-compatible API. Configure with `base_url` in `swe_team.yaml`. |
+
+### 2.2 NotificationProvider
+
+The `NotificationProvider` interface handles all outgoing notifications. SWE-Squad uses it to alert engineers about new incidents, fix approvals, escalations, and deployment events.
+
+```python
+class NotificationProvider(BaseProvider):
+    """Abstract interface for notification delivery backends."""
+
+    @abstractmethod
+    async def send_notification(self, recipient: str, message: str, **kwargs) -> bool:
+        """Send a notification to a single recipient.
+
+        Args:
+            recipient: The recipient identifier (email, channel, user ID, etc.).
+            message: The notification message body.
+            **kwargs: Optional overrides such as channel, subject, priority, or attachments.
+
+        Returns:
+            True if the notification was sent successfully, False otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def send_batch(self, recipients: list[str], message: str) -> dict:
+        """Send the same notification to multiple recipients.
+
+        Args:
+            recipients: A list of recipient identifiers.
+            message: The notification message body.
+
+        Returns:
+            A dict mapping each recipient to a boolean success indicator.
+        """
+        ...
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `send_notification(recipient, message, **kwargs)` | `bool` | Send a notification to a single recipient. Supports `channel`, `subject`, `priority`, and `attachments` keyword arguments. |
+| `send_batch(recipients, message)` | `dict` | Send the same message to multiple recipients. Returns a dict mapping each recipient to a boolean indicating success or failure. |
+
+**Built-in implementations:**
+
+| Implementation | Description |
+|---------------|-------------|
+| `EmailNotificationProvider` | Sends notifications via email using SMTP. Configured with `SMTP_HOST`, `SMTP_PORT`, and `SMTP_FROM` environment variables. |
+| `WebhookNotificationProvider` | Posts JSON payloads to a configurable webhook URL. Useful for custom integrations and chatops pipelines. |
+
+### 2.3 IssueTracker
+
+The `IssueTracker` interface wraps issue tracking systems. SWE-Squad uses it to create, read, update, and list issues during incident management.
+
+```python
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Issue:
+    """Represents a tracked issue."""
+    id: str
+    title: str
+    body: str
+    status: str
+    labels: list[str]
+    assignee: Optional[str] = None
+    metadata: Optional[dict] = None
+
+class IssueTracker(BaseProvider):
+    """Abstract interface for issue tracking backends."""
+
+    @abstractmethod
+    async def create_issue(self, title: str, body: str, **kwargs) -> Issue:
+        """Create a new issue.
+
+        Args:
+            title: The issue title.
+            body: The issue body in markdown.
+            **kwargs: Optional fields such as labels, assignee, and metadata.
+
+        Returns:
+            The created Issue object with its assigned ID.
+        """
+        ...
+
+    @abstractmethod
+    async def get_issue(self, id: str) -> Issue:
+        """Retrieve an issue by its identifier.
+
+        Args:
+            id: The issue identifier.
+
+        Returns:
+            The Issue object.
+        """
+        ...
+
+    @abstractmethod
+    async def update_issue(self, id: str, **kwargs) -> Issue:
+        """Update an existing issue.
+
+        Args:
+            id: The issue identifier.
+            **kwargs: Fields to update such as status, labels, assignee, or body.
+
+        Returns:
+            The updated Issue object.
+        """
+        ...
+
+    @abstractmethod
+    async def list_issues(self, **kwargs) -> list[Issue]:
+        """List issues matching the given filters.
+
+        Args:
+            **kwargs: Filter criteria such as status, labels, assignee, or since.
+
+        Returns:
+            A list of matching Issue objects.
+        """
+        ...
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create_issue(title, body, **kwargs)` | `Issue` | Create a new issue. Accepts `labels`, `assignee`, and `metadata` keyword arguments. |
+| `get_issue(id)` | `Issue` | Retrieve a single issue by its unique identifier. |
+| `update_issue(id, **kwargs)` | `Issue` | Update fields on an existing issue. Accepts `status`, `labels`, `assignee`, and `body` keyword arguments. |
+| `list_issues(**kwargs)` | `list[Issue]` | List issues matching filters. Accepts `status`, `labels`, `assignee`, and `since` keyword arguments. |
+
+**Built-in implementations:**
+
+| Implementation | Description |
+|---------------|-------------|
+| `GitHubIssueTracker` | Default tracker. Uses the GitHub REST API with the `GITHUB_TOKEN` environment variable. Supports labels, milestones, and assignees. |
+| `JiraIssueTracker` | Connects to Jira Cloud or Jira Server. Configured with `JIRA_URL`, `JIRA_USER`, and `JIRA_TOKEN` environment variables. |
+| `LinearIssueTracker` | Connects to Linear via the Linear API. Configured with `LINEAR_API_KEY` and `LINEAR_TEAM_ID` environment variables. |
+
+### 2.4 SandboxProvider
+
+The `SandboxProvider` interface manages isolated execution environments. SWE-Squad uses sandboxes to run agent-generated commands, tests, and validation scripts in a safe, reproducible manner.
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class SandboxHandle:
+    """Opaque handle to a running sandbox instance."""
+    id: str
+    created_at: str
+    config: dict
+
+@dataclass
+class ExecutionResult:
+    """Result of a command executed inside a sandbox."""
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+class SandboxProvider(BaseProvider):
+    """Abstract interface for isolated execution environments."""
+
+    @abstractmethod
+    async def create_sandbox(self, config: dict) -> SandboxHandle:
+        """Create a new sandbox instance.
+
+        Args:
+            config: Sandbox configuration including image, memory limit,
+                    CPU limit, environment variables, and mount points.
+
+        Returns:
+            A SandboxHandle identifying the created instance.
+        """
+        ...
+
+    @abstractmethod
+    async def execute(self, handle: SandboxHandle, command: str) -> ExecutionResult:
+        """Execute a command inside the sandbox.
+
+        Args:
+            handle: The sandbox handle returned by create_sandbox.
+            command: The shell command to execute.
+
+        Returns:
+            An ExecutionResult with exit code, stdout, stderr, and duration.
+        """
+        ...
+
+    @abstractmethod
+    async def destroy(self, handle: SandboxHandle) -> None:
+        """Destroy the sandbox and release all resources.
+
+        Args:
+            handle: The sandbox handle to destroy.
+        """
+        ...
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `create_sandbox(config)` | `SandboxHandle` | Create a new isolated environment. The `config` dict accepts `image`, `memory`, `cpu`, `env`, and `mounts` keys. |
+| `execute(handle, command)` | `ExecutionResult` | Run a shell command inside the sandbox. Returns exit code, stdout, stderr, and execution duration. |
+| `destroy(handle)` | `None` | Tear down the sandbox and release all associated resources. |
+
+**Built-in implementations:**
+
+| Implementation | Description |
+|---------------|-------------|
+| `DockerSandboxProvider` | Default sandbox. Uses Docker containers with configurable images, memory limits, and network isolation. Enabled with `SWE_DOCKER_ENABLED=true`. |
+| `LocalSandboxProvider` | Runs commands directly on the host with subprocess isolation. Intended for development only. No network or filesystem isolation. |
+
+### 2.5 EmbeddingProvider
+
+The `EmbeddingProvider` interface handles text embedding generation. SWE-Squad uses embeddings for semantic memory matching, similarity search, and trajectory distillation.
+
+```python
+class EmbeddingProvider(BaseProvider):
+    """Abstract interface for text embedding backends."""
+
+    @abstractmethod
+    async def embed(self, text: str) -> list[float]:
+        """Generate an embedding vector for a single text input.
+
+        Args:
+            text: The input text to embed.
+
+        Returns:
+            A list of floats representing the embedding vector.
+        """
+        ...
+
+    @abstractmethod
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embedding vectors for multiple text inputs.
+
+        Args:
+            texts: A list of input strings to embed.
+
+        Returns:
+            A list of embedding vectors, one per input text.
+        """
+        ...
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `embed(text)` | `list[float]` | Generate a single embedding vector for the input text. |
+| `embed_batch(texts)` | `list[list[float]]` | Generate embedding vectors for a batch of inputs. More efficient than calling `embed` in a loop for large batches. |
+
+**Built-in implementations:**
+
+| Implementation | Description |
+|---------------|-------------|
+| `OpenAIEmbeddingProvider` | Uses OpenAI's embedding API (text-embedding-3-small by default). Configured with `OPENAI_API_KEY`. |
+| `LocalEmbeddingProvider` | Runs sentence-transformers locally. No API key required. Suitable for air-gapped environments. |
+
+### 2.6 VectorStore
+
+The `VectorStore` interface wraps vector databases used for semantic memory storage and retrieval. SWE-Squad stores issue embeddings, fix trajectories, and distilled playbooks in the vector store.
+
+```python
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class SearchResult:
+    """A single result from a vector similarity search."""
+    id: str
+    score: float
+    metadata: Optional[dict] = None
+
+class VectorStore(BaseProvider):
+    """Abstract interface for vector storage backends."""
+
+    @abstractmethod
+    async def upsert(self, id: str, embedding: list[float], metadata: dict) -> None:
+        """Insert or update a vector entry.
+
+        Args:
+            id: Unique identifier for the entry.
+            embedding: The embedding vector.
+            metadata: Optional metadata dict to store alongside the vector.
+        """
+        ...
+
+    @abstractmethod
+    async def query(self, embedding: list[float], k: int = 10) -> list[SearchResult]:
+        """Search for the k nearest neighbors of the given embedding.
+
+        Args:
+            embedding: The query embedding vector.
+            k: The number of results to return.
+
+        Returns:
+            A list of SearchResult objects sorted by similarity score.
+        """
+        ...
+
+    @abstractmethod
+    async def delete(self, ids: list[str]) -> None:
+        """Delete entries by their identifiers.
+
+        Args:
+            ids: A list of entry identifiers to delete.
+        """
+        ...
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `upsert(id, embedding, metadata)` | `None` | Insert a new entry or update an existing one if the ID already exists. |
+| `query(embedding, k)` | `list[SearchResult]` | Return the `k` most similar entries to the given embedding. Results include ID, similarity score, and stored metadata. |
+| `delete(ids)` | `None` | Remove one or more entries by their identifiers. |
+
+**Built-in implementations:**
+
+| Implementation | Description |
+|---------------|-------------|
+| `PineconeVectorStore` | Connects to Pinecone via its REST API. Configured with `PINECONE_API_KEY` and `PINECONE_INDEX` environment variables. |
+| `WeaviateVectorStore` | Connects to a Weaviate instance. Configured with `WEAVIATE_URL` environment variable. |
+| `ChromaVectorStore` | Uses ChromaDB as an embedded vector store. No external service required. Ideal for development and single-node deployments. |
+
+### 2.7 TaskQueueProvider
+
+The `TaskQueueProvider` interface wraps asynchronous task queue systems. SWE-Squad uses task queues for distributed remote worker coordination, background incident processing, and long-running fix orchestration.
+
+```python
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Task:
+    """Represents a queued task."""
+    id: str
+    payload: dict
+    queue: str
+    status: str
+    created_at: Optional[str] = None
+
+class TaskQueueProvider(BaseProvider):
+    """Abstract interface for async task queue backends."""
+
+    @abstractmethod
+    async def enqueue(self, task: dict, queue: str = "default") -> str:
+        """Add a task to the queue.
+
+        Args:
+            task: The task payload as a dict.
+            queue: The queue name. Defaults to "default".
+
+        Returns:
+            The assigned task ID.
+        """
+        ...
+
+    @abstractmethod
+    async def dequeue(self, queue: str = "default") -> Task:
+        """Retrieve and remove the next task from the queue.
+
+        Args:
+            queue: The queue name. Defaults to "default".
+
+        Returns:
+            The next Task object from the queue.
+        """
+        ...
+
+    @abstractmethod
+    async def acknowledge(self, task_id: str) -> None:
+        """Acknowledge that a task has been processed successfully.
+
+        Args:
+            task_id: The ID of the task to acknowledge.
+        """
+        ...
+
+    @abstractmethod
+    async def queue_size(self, queue: str = "default") -> int:
+        """Return the number of pending tasks in the queue.
+
+        Args:
+            queue: The queue name. Defaults to "default".
+
+        Returns:
+            The number of pending tasks.
+        """
+        ...
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `enqueue(task, queue)` | `str` | Add a task to the named queue and return its assigned ID. |
+| `dequeue(queue)` | `Task` | Pop the next task from the named queue. Blocks until a task is available. |
+| `acknowledge(task_id)` | `None` | Mark a task as successfully processed. Required for at-least-once delivery semantics. |
+| `queue_size(queue)` | `int` | Return the number of pending (unacknowledged) tasks in the queue. |
+
+**Built-in implementations:**
+
+| Implementation | Description |
+|---------------|-------------|
+| `RedisTaskQueue` | Default queue backend. Uses Redis LIST and SET operations. Configured with the `remote.redis_url` setting in `swe_team.yaml`. |
+| `CeleryTaskQueue` | Uses Celery with a configurable broker (Redis or RabbitMQ). Suitable for complex workflow orchestration with task chaining. |
+| `SQSTaskQueue` | Uses Amazon SQS. Configured with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` environment variables. |
+| `MemoryTaskQueue` | In-process async queue using Python's `asyncio.Queue`. Intended for development and testing only. |
+
+---
+
+## 3. Step-by-Step Tutorial: Building a Custom NotificationProvider (Slack)
+
+This section walks through building a complete Slack notification provider from scratch. The finished provider will support single and batch notifications, rate limiting, retries, and proper error handling.
+
+### Prerequisites
+
+Before you begin, ensure you have the following:
+
+- **Python 3.11+** installed on your development machine
+- A **Slack workspace** with permission to create bots
+- A **Slack Bot User OAuth Token** starting with `xoxb-`. Create one at `api.slack.com/apps` by creating a new app, attaching it to your workspace, and granting it the `chat:write` and `chat:write.public` bot token scopes
+- The `aiohttp` package installed (`pip install aiohttp`) for async HTTP requests
+- A running SWE-Squad development environment (see the [Configuration Reference](/docs/configuration-reference) for setup instructions)
+
+### Step 1: Create the Provider File
+
+Create a new Python module for your provider. Place it in the `providers/` directory at the root of your SWE-Squad installation:
+
+```bash
+mkdir -p providers
+touch providers/__init__.py
+touch providers/slack_provider.py
+```
+
+The directory structure should look like this:
+
+```
+your-project/
+  providers/
+    __init__.py
+    slack_provider.py
+  swe_team.yaml
+  ...
+```
+
+### Step 2: Implement the NotificationProvider Interface
+
+Open `providers/slack_provider.py` and implement the `NotificationProvider` abstract class:
+
+```python
+"""Slack notification provider for SWE-Squad."""
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+
+from swe_team.providers import NotificationProvider, ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class SlackNotificationProvider(NotificationProvider):
+    """Send SWE-Squad notifications to Slack channels and users."""
+
+    def __init__(self, bot_token: str, default_channel: str):
+        self.bot_token = bot_token
+        self.default_channel = default_channel
+        self._client: aiohttp.ClientSession | None = None
+        self._base_url = "https://slack.com/api/chat.postMessage"
+
+    async def initialize(self, config: dict) -> None:
+        """Initialize the aiohttp session."""
+        self._client = aiohttp.ClientSession(
+            headers={
+                "Authorization": f"Bearer {self.bot_token}",
+                "Content-Type": "application/json",
+            }
+        )
+        logger.info("SlackNotificationProvider initialized for channel %s",
+                     self.default_channel)
+
+    async def shutdown(self) -> None:
+        """Close the aiohttp session."""
+        if self._client and not self._client.closed:
+            await self._client.close()
+            logger.info("SlackNotificationProvider shut down")
+
+    def health_check(self) -> bool:
+        """Check whether the HTTP client session is active."""
+        return self._client is not None and not self._client.closed
+
+    async def send_notification(
+        self, recipient: str, message: str, **kwargs: Any
+    ) -> bool:
+        """Send a notification to a Slack channel or user.
+
+        Args:
+            recipient: A Slack user ID (e.g. @U12345678), channel name
+                       (e.g. #general), or channel ID (e.g. C12345678).
+            message: The notification text.
+            **kwargs: Optional overrides:
+                - channel: Override the target channel.
+                - blocks: Slack Block Kit blocks for rich formatting.
+                - unfurl_links: Whether to unfurl links (default False).
+
+        Returns:
+            True if Slack accepted the message, False otherwise.
+        """
+        channel = kwargs.get("channel", self._resolve_channel(recipient))
+        payload: dict[str, Any] = {
+            "channel": channel,
+            "text": message,
+            "unfurl_links": kwargs.get("unfurl_links", False),
+        }
+        if "blocks" in kwargs:
+            payload["blocks"] = kwargs["blocks"]
+
+        return await self._post_message(payload)
+
+    async def send_batch(
+        self, recipients: list[str], message: str
+    ) -> dict[str, bool]:
+        """Send the same message to multiple recipients.
+
+        Args:
+            recipients: A list of Slack user IDs or channel names.
+            message: The notification text.
+
+        Returns:
+            A dict mapping each recipient to a boolean success indicator.
+        """
+        results: dict[str, bool] = {}
+        for recipient in recipients:
+            results[recipient] = await self.send_notification(recipient, message)
+            # Respect Slack rate limits: space out messages by 300ms
+            await asyncio.sleep(0.3)
+        return results
+
+    def _resolve_channel(self, recipient: str) -> str:
+        """Resolve a recipient string to a Slack channel identifier.
+
+        If the recipient starts with '#', treat it as a channel name.
+        If it starts with '@', treat it as a user ID for a DM.
+        Otherwise, fall back to the default channel.
+        """
+        if recipient.startswith("#") or recipient.startswith("@"):
+            return recipient
+        if recipient.startswith("C") or recipient.startswith("D"):
+            return recipient
+        return self.default_channel
+
+    async def _post_message(self, payload: dict[str, Any]) -> bool:
+        """Post a message to the Slack API with basic error handling.
+
+        Args:
+            payload: The JSON payload to send.
+
+        Returns:
+            True if the API responded with ok=true, False otherwise.
+        """
+        if not self._client:
+            logger.error("SlackNotificationProvider not initialized")
+            return False
+
+        try:
+            async with self._client.post(self._base_url, json=payload) as resp:
+                body = await resp.json()
+                if body.get("ok"):
+                    logger.debug("Slack message sent to %s", payload["channel"])
+                    return True
+                else:
+                    logger.error(
+                        "Slack API error: %s", body.get("error", "unknown")
+                    )
+                    return False
+        except aiohttp.ClientError as exc:
+            logger.error("HTTP error sending Slack message: %s", exc)
+            return False
+```
+
+Key design decisions in this implementation:
+
+- The `aiohttp.ClientSession` is created in `initialize()` and closed in `shutdown()`, matching the `BaseProvider` lifecycle contract.
+- `_resolve_channel()` handles three common recipient formats: channel names (`#general`), user mentions (`@U12345678`), and raw channel IDs (`C12345678`), falling back to the configured default channel.
+- `send_batch()` spaces messages 300 milliseconds apart to stay within Slack's rate limits.
+- All errors are logged and returned as `False` rather than raised, matching the interface contract that expects a boolean return.
+
+### Step 3: Add Error Handling, Retries, and Rate Limiting
+
+Production Slack integrations must handle transient failures, rate limiting responses, and network timeouts gracefully. Extend the `_post_message` method with retry logic:
+
+```python
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class SlackNotificationProvider(NotificationProvider):
+    """Send SWE-Squad notifications to Slack channels and users."""
+
+    MAX_RETRIES = 3
+    RETRY_BASE_DELAY = 1.0  # seconds
+
+    def __init__(self, bot_token: str, default_channel: str):
+        self.bot_token = bot_token
+        self.default_channel = default_channel
+        self._client: aiohttp.ClientSession | None = None
+        self._base_url = "https://slack.com/api/chat.postMessage"
+
+    async def initialize(self, config: dict) -> None:
+        """Initialize the aiohttp session with retry-friendly timeouts."""
+        timeout = aiohttp.ClientTimeout(total=30, connect=10)
+        self._client = aiohttp.ClientSession(
+            headers={
+                "Authorization": f"Bearer {self.bot_token}",
+                "Content-Type": "application/json",
+            },
+            timeout=timeout,
+        )
+        logger.info("SlackNotificationProvider initialized for channel %s",
+                     self.default_channel)
+
+    async def shutdown(self) -> None:
+        """Close the aiohttp session."""
+        if self._client and not self._client.closed:
+            await self._client.close()
+            logger.info("SlackNotificationProvider shut down")
+
+    def health_check(self) -> bool:
+        """Check whether the HTTP client session is active."""
+        return self._client is not None and not self._client.closed
+
+    async def send_notification(
+        self, recipient: str, message: str, **kwargs: Any
+    ) -> bool:
+        """Send a notification to a Slack channel or user."""
+        channel = kwargs.get("channel", self._resolve_channel(recipient))
+        payload: dict[str, Any] = {
+            "channel": channel,
+            "text": message,
+            "unfurl_links": kwargs.get("unfurl_links", False),
+        }
+        if "blocks" in kwargs:
+            payload["blocks"] = kwargs["blocks"]
+
+        return await self._post_message(payload)
+
+    async def send_batch(
+        self, recipients: list[str], message: str
+    ) -> dict[str, bool]:
+        """Send the same message to multiple recipients."""
+        results: dict[str, bool] = {}
+        for recipient in recipients:
+            results[recipient] = await self.send_notification(recipient, message)
+            await asyncio.sleep(0.3)
+        return results
+
+    def _resolve_channel(self, recipient: str) -> str:
+        """Resolve a recipient string to a Slack channel identifier."""
+        if recipient.startswith("#") or recipient.startswith("@"):
+            return recipient
+        if recipient.startswith("C") or recipient.startswith("D"):
+            return recipient
+        return self.default_channel
+
+    async def _post_message(self, payload: dict[str, Any]) -> bool:
+        """Post a message to the Slack API with retries and rate limit handling.
+
+        Retries up to MAX_RETRIES times with exponential backoff. Handles
+        Slack's HTTP 429 rate limit response by respecting the Retry-After
+        header.
+
+        Args:
+            payload: The JSON payload to send.
+
+        Returns:
+            True if the message was accepted, False after exhausting retries.
+        """
+        if not self._client:
+            logger.error("SlackNotificationProvider not initialized")
+            return False
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                async with self._client.post(
+                    self._base_url, json=payload
+                ) as resp:
+                    # Handle Slack rate limiting
+                    if resp.status == 429:
+                        retry_after = int(
+                            resp.headers.get("Retry-After", "60")
+                        )
+                        logger.warning(
+                            "Slack rate limited. Retrying after %ds "
+                            "(attempt %d/%d)",
+                            retry_after, attempt + 1, self.MAX_RETRIES
+                        )
+                        await asyncio.sleep(retry_after)
+                        continue
+
+                    body = await resp.json()
+                    if body.get("ok"):
+                        logger.debug(
+                            "Slack message sent to %s", payload["channel"]
+                        )
+                        return True
+
+                    error = body.get("error", "unknown")
+                    # Do not retry client errors (except rate limiting)
+                    if error in ("channel_not_found", "not_authed",
+                                 "invalid_auth", "account_inactive"):
+                        logger.error(
+                            "Slack API client error: %s (not retryable)", error
+                        )
+                        return False
+
+                    logger.warning(
+                        "Slack API error: %s (attempt %d/%d)",
+                        error, attempt + 1, self.MAX_RETRIES
+                    )
+
+            except aiohttp.ClientError as exc:
+                logger.warning(
+                    "HTTP error sending Slack message: %s (attempt %d/%d)",
+                    exc, attempt + 1, self.MAX_RETRIES
+                )
+
+            # Exponential backoff before retrying
+            delay = self.RETRY_BASE_DELAY * (2 ** attempt)
+            logger.info("Retrying in %.1fs", delay)
+            await asyncio.sleep(delay)
+
+        logger.error(
+            "Failed to send Slack message after %d attempts",
+            self.MAX_RETRIES
+        )
+        return False
+```
+
+The retry logic handles three categories of failure:
+
+- **Rate limiting (HTTP 429):** Reads the `Retry-After` header and sleeps for the specified duration before retrying.
+- **Transient errors (network failures, server errors):** Retries with exponential backoff starting at 1 second.
+- **Client errors (invalid auth, missing channel):** Returns `False` immediately without retrying, since these errors will not resolve themselves.
+
+### Step 4: Register the Provider
+
+There are two ways to register your custom provider: programmatically or through `swe_team.yaml`. The YAML approach is recommended because it keeps configuration separate from code and works with the standard startup sequence.
+
+**Programmatic registration** is useful for testing or dynamic setup:
+
+```python
+from providers.slack_provider import SlackNotificationProvider
+from swe_team.providers import ProviderRegistry
+
+# Create the provider instance
+slack = SlackNotificationProvider(
+    bot_token="xoxb-your-token-here",
+    default_channel="#swe-squad-alerts"
+)
+
+# Initialize it
+await slack.initialize({})
+
+# Register with the global registry
+registry = ProviderRegistry.instance()
+registry.register("notifications", "slack", slack)
+
+# Verify it works
+assert registry.get("notifications", "slack").health_check()
+```
+
+The YAML registration approach is covered in detail in the next section.
+
+---
+
+## 4. Registration in swe_team.yaml
+
+Custom providers are registered in the `providers` section of `swe_team.yaml`. The configuration system dynamically loads the specified Python module, instantiates the class, and registers it with the `ProviderRegistry` at startup.
+
+### Basic Registration
+
+Add a `custom` block under the relevant provider type in your `swe_team.yaml`:
+
+```yaml
+providers:
+  notifications:
+    default: "slack"
+    custom:
+      slack:
+        module: "providers.slack_provider"
+        class: "SlackNotificationProvider"
+        config:
+          bot_token_env: "SLACK_BOT_TOKEN"
+          default_channel: "#swe-squad-alerts"
+```
+
+The registration schema for custom providers is:
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `module` | string | yes | Dotted Python module path to the provider file. Must be importable from the SWE-Squad root directory. |
+| `class` | string | yes | Name of the provider class within the module. Must inherit from the correct abstract interface. |
+| `config` | object | no | Configuration dict passed to the provider's `initialize()` method. |
+| `config.bot_token_env` | string | no | Name of the environment variable containing the API token. The startup loader reads this variable and passes the value to the provider. |
+| `config.default_channel` | string | no | Default Slack channel for notifications when no channel is specified. |
+
+Set the corresponding environment variable:
+
+```bash
+export SLACK_BOT_TOKEN="xoxb-your-bot-token-here"
+```
+
+### Registration for Other Provider Types
+
+The same pattern applies to all seven provider types. Each type has its own top-level key under `providers`:
+
+```yaml
+providers:
+  # LLM coding engine
+  coding:
+    default: "anthropic"
+    custom:
+      my_local_llm:
+        module: "providers.my_local_provider"
+        class: "MyLocalLLMProvider"
+        config:
+          base_url: "http://localhost:8080/v1"
+          model: "llama-3.1-70b"
+
+  # Notification backends
+  notifications:
+    default: "slack"
+    custom:
+      slack:
+        module: "providers.slack_provider"
+        class: "SlackNotificationProvider"
+        config:
+          bot_token_env: "SLACK_BOT_TOKEN"
+          default_channel: "#swe-squad-alerts"
+
+  # Issue tracking systems
+  issues:
+    default: "github"
+    custom:
+      linear:
+        module: "providers.linear_provider"
+        class: "LinearIssueTracker"
+        config:
+          api_key_env: "LINEAR_API_KEY"
+          team_id_env: "LINEAR_TEAM_ID"
+
+  # Sandboxed execution
+  sandbox:
+    default: "docker"
+    custom:
+      firecracker:
+        module: "providers.firecracker_provider"
+        class: "FirecrackerSandboxProvider"
+        config:
+          kernel_path: "/var/lib/firecracker/vmlinux"
+          rootfs_path: "/var/lib/firecracker/rootfs.ext4"
+
+  # Text embeddings
+  embedding:
+    default: "openai"
+    custom:
+      local:
+        module: "providers.local_embedding"
+        class: "LocalEmbeddingProvider"
+        config:
+          model_name: "all-MiniLM-L6-v2"
+
+  # Vector storage
+  vectorstore:
+    default: "chroma"
+    custom:
+      pinecone:
+        module: "providers.pinecone_store"
+        class: "PineconeVectorStore"
+        config:
+          api_key_env: "PINECONE_API_KEY"
+          index_name: "swe-squad-memory"
+          dimension: 1536
+
+  # Task queues
+  taskqueue:
+    default: "redis"
+    custom:
+      sqs:
+        module: "providers.sqs_queue"
+        class: "SQSTaskQueue"
+        config:
+          region: "us-east-1"
+          queue_url: "https://sqs.us-east-1.amazonaws.com/123456789/swe-tasks"
+```
+
+### Per-Agent Notification Overrides
+
+Some teams want specific agents to use different notification channels. For example, the reviewer agent might post to a dedicated review channel while the coder sends status updates to the general alerts channel. Configure this in the `agents` section:
+
+```yaml
+providers:
+  notifications:
+    default: "slack"
+    custom:
+      slack:
+        module: "providers.slack_provider"
+        class: "SlackNotificationProvider"
+        config:
+          bot_token_env: "SLACK_BOT_TOKEN"
+          default_channel: "#swe-squad-alerts"
+
+agents:
+  explorer:
+    notifications:
+      channel: "#swe-exploration"
+  reviewer:
+    notifications:
+      channel: "#swe-reviews"
+      priority: "high"
+  coder:
+    notifications:
+      channel: "#swe-deploys"
+```
+
+The per-agent notification settings are passed as keyword arguments when the agent calls `send_notification()`, allowing the provider to route messages to the correct channel.
+
+### Multiple Providers of the Same Type
+
+You can register multiple providers under the same interface type and switch between them by changing the `default` key:
+
+```yaml
+providers:
+  notifications:
+    default: "slack"
+    custom:
+      slack:
+        module: "providers.slack_provider"
+        class: "SlackNotificationProvider"
+        config:
+          bot_token_env: "SLACK_BOT_TOKEN"
+          default_channel: "#swe-squad-alerts"
+      discord:
+        module: "providers.discord_provider"
+        class: "DiscordNotificationProvider"
+        config:
+          webhook_url_env: "DISCORD_WEBHOOK_URL"
+          default_username: "SWE-Squad Bot"
+```
+
+To switch from Slack to Discord, change `default` from `"slack"` to `"discord"`. No code changes required. You can also route specific agents to specific providers:
+
+```yaml
+providers:
+  notifications:
+    default: "slack"
+    custom:
+      slack:
+        module: "providers.slack_provider"
+        class: "SlackNotificationProvider"
+        config:
+          bot_token_env: "SLACK_BOT_TOKEN"
+          default_channel: "#swe-squad-alerts"
+      discord:
+        module: "providers.discord_provider"
+        class: "DiscordNotificationProvider"
+        config:
+          webhook_url_env: "DISCORD_WEBHOOK_URL"
+
+agents:
+  explorer:
+    notifications:
+      provider: "discord"
+  reviewer:
+    notifications:
+      provider: "slack"
+```
+
+### Startup Loading Process
+
+When SWE-Squad starts, the configuration loader processes the `providers` section in this order:
+
+1. Read `swe_team.yaml` and parse the `providers` section.
+2. For each provider type (coding, notifications, issues, etc.), identify the `default` provider.
+3. For each entry under `custom`, import the specified `module` using Python's importlib.
+4. Instantiate the specified `class`, passing the `config` dict to the constructor.
+5. Call the provider's `initialize()` method with the full config dict. If `config` contains `*_env` keys, the loader resolves the environment variable values before passing them.
+6. Register the instance with `ProviderRegistry` under the interface type and provider name.
+7. Run `health_check()` on the default provider for each type. If it returns `False`, log a warning but continue startup.
+
+If a custom module fails to import or a class fails to instantiate, SWE-Squad logs the error and falls back to the built-in default for that provider type. The pipeline does not crash due to a misconfigured custom provider.
+
+---
+
+## 5. Testing Provider Implementations
+
+Thorough testing is critical for provider plugins because they wrap external services with complex failure modes. This section covers unit testing, integration testing, and contract validation patterns.
+
+### Unit Testing with Mocks
+
+Unit tests verify your provider's logic without making real network calls. Mock the HTTP layer and assert that your provider handles responses correctly.
+
+Create a test file at `tests/test_slack_provider.py`:
+
+```python
+"""Unit tests for SlackNotificationProvider."""
+
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from providers.slack_provider import SlackNotificationProvider
+
+
+@pytest.fixture
+def provider():
+    """Create a provider instance for testing."""
+    return SlackNotificationProvider(
+        bot_token="xoxb-test-token",
+        default_channel="#test-channel"
+    )
+
+
+@pytest.fixture
+async def initialized_provider(provider):
+    """Create and initialize a provider with a mocked HTTP session."""
+    await provider.initialize({})
+    yield provider
+    await provider.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_health_check_before_initialize(provider):
+    """health_check returns False before initialize() is called."""
+    assert provider.health_check() is False
+
+
+@pytest.mark.asyncio
+async def test_health_check_after_initialize(initialized_provider):
+    """health_check returns True after initialize() is called."""
+    assert initialized_provider.health_check() is True
+
+
+@pytest.mark.asyncio
+async def test_health_check_after_shutdown(initialized_provider):
+    """health_check returns False after shutdown() is called."""
+    await initialized_provider.shutdown()
+    assert initialized_provider.health_check() is False
+
+
+@pytest.mark.asyncio
+async def test_send_notification_success(initialized_provider):
+    """send_notification returns True when Slack API accepts the message."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"ok": True})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    initialized_provider._client.post = MagicMock(return_value=mock_response)
+
+    result = await initialized_provider.send_notification(
+        "@U12345678", "Test message"
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_send_notification_api_error(initialized_provider):
+    """send_notification returns False when Slack API returns an error."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={
+        "ok": False,
+        "error": "channel_not_found"
+    })
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    initialized_provider._client.post = MagicMock(return_value=mock_response)
+
+    result = await initialized_provider.send_notification(
+        "#nonexistent", "Test message"
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_notification_rate_limited(initialized_provider):
+    """send_notification retries on HTTP 429 and eventually succeeds."""
+    rate_limited_response = AsyncMock()
+    rate_limited_response.status = 429
+    rate_limited_response.headers = {"Retry-After": "0"}
+    rate_limited_response.__aenter__ = AsyncMock(
+        return_value=rate_limited_response
+    )
+    rate_limited_response.__aexit__ = AsyncMock(return_value=False)
+
+    success_response = AsyncMock()
+    success_response.status = 200
+    success_response.json = AsyncMock(return_value={"ok": True})
+    success_response.__aenter__ = AsyncMock(return_value=success_response)
+    success_response.__aexit__ = AsyncMock(return_value=False)
+
+    initialized_provider._client.post = MagicMock(
+        side_effect=[rate_limited_response, success_response]
+    )
+
+    # Patch asyncio.sleep to avoid real delays in tests
+    with patch("providers.slack_provider.asyncio.sleep",
+               new_callable=AsyncMock):
+        result = await initialized_provider.send_notification(
+            "@U12345678", "Test message"
+        )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_send_notification_network_error(initialized_provider):
+    """send_notification returns False after exhausting retries."""
+    import aiohttp
+
+    initialized_provider._client.post = MagicMock(
+        side_effect=aiohttp.ClientError("Connection refused")
+    )
+
+    with patch("providers.slack_provider.asyncio.sleep",
+               new_callable=AsyncMock):
+        result = await initialized_provider.send_notification(
+            "@U12345678", "Test message"
+        )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_batch(initialized_provider):
+    """send_batch returns a dict mapping each recipient to its result."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"ok": True})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    initialized_provider._client.post = MagicMock(return_value=mock_response)
+
+    with patch("providers.slack_provider.asyncio.sleep",
+               new_callable=AsyncMock):
+        results = await initialized_provider.send_batch(
+            ["@user1", "@user2", "@user3"], "Batch test message"
+        )
+
+    assert results == {
+        "@user1": True,
+        "@user2": True,
+        "@user3": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_notification_not_initialized(provider):
+    """send_notification returns False if the provider is not initialized."""
+    result = await provider.send_notification("@user", "message")
+    assert result is False
+
+
+def test_resolve_channel_with_hash(provider):
+    """Channel names starting with # are passed through."""
+    assert provider._resolve_channel("#general") == "#general"
+
+
+def test_resolve_channel_with_at(provider):
+    """User IDs starting with @ are passed through."""
+    assert provider._resolve_channel("@U12345678") == "@U12345678"
+
+
+def test_resolve_channel_with_channel_id(provider):
+    """Channel IDs starting with C are passed through."""
+    assert provider._resolve_channel("C12345678") == "C12345678"
+
+
+def test_resolve_channel_fallback(provider):
+    """Unknown formats fall back to the default channel."""
+    assert provider._resolve_channel("unknown") == "#test-channel"
+```
+
+### Integration Testing Patterns
+
+Integration tests verify that your provider works correctly against the real external service. These tests are slower and require real credentials, so they should be marked separately and run only in CI or on demand.
+
+```python
+"""Integration tests for SlackNotificationProvider.
+
+Requires the SLACK_BOT_TOKEN environment variable to be set.
+Run with: pytest -m integration tests/test_slack_integration.py
+"""
+
+import os
+import pytest
+
+from providers.slack_provider import SlackNotificationProvider
+
+
+@pytest.fixture
+async def live_provider():
+    """Create a provider connected to the real Slack API."""
+    token = os.environ.get("SLACK_BOT_TOKEN")
+    if not token:
+        pytest.skip("SLACK_BOT_TOKEN not set")
+
+    provider = SlackNotificationProvider(
+        bot_token=token,
+        default_channel="#swe-squad-test"
+    )
+    await provider.initialize({})
+    yield provider
+    await provider.shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_live_send_notification(live_provider):
+    """Send a real notification to the test channel."""
+    result = await live_provider.send_notification(
+        "#swe-squad-test",
+        "Integration test message from SWE-Squad provider tests."
+    )
+    assert result is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_live_send_batch(live_provider):
+    """Send batch notifications to the test channel."""
+    results = await live_provider.send_batch(
+        ["#swe-squad-test"],
+        "Batch integration test message."
+    )
+    assert all(results.values())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_live_health_check(live_provider):
+    """Verify health check passes with a live connection."""
+    assert live_provider.health_check() is True
+```
+
+Run unit tests and integration tests separately:
+
+```bash
+# Unit tests only (fast, no network)
+pytest tests/test_slack_provider.py -v
+
+# Integration tests only (requires SLACK_BOT_TOKEN)
+pytest -m integration tests/test_slack_integration.py -v
+
+# All tests
+pytest tests/ -v
+```
+
+### Testing Against the Provider Contract
+
+Every provider must implement all abstract methods defined by its interface. Use a contract test to verify that no methods are missing:
+
+```python
+"""Contract tests to verify provider implementations satisfy their interface."""
+
+import inspect
+from abc import ABC
+
+import pytest
+
+from swe_team.providers import (
+    BaseProvider,
+    NotificationProvider,
+    CodingEngine,
+    IssueTracker,
+    SandboxProvider,
+    EmbeddingProvider,
+    VectorStore,
+    TaskQueueProvider,
+)
+from providers.slack_provider import SlackNotificationProvider
+
+
+def test_slack_provider_inherits_notification_provider():
+    """SlackNotificationProvider must inherit from NotificationProvider."""
+    assert issubclass(SlackNotificationProvider, NotificationProvider)
+
+
+def test_slack_provider_inherits_base_provider():
+    """SlackNotificationProvider must inherit from BaseProvider."""
+    assert issubclass(SlackNotificationProvider, BaseProvider)
+
+
+def test_all_abstract_methods_implemented():
+    """All abstract methods from the interface must be implemented."""
+
+    abstract_methods = set()
+    for cls in SlackNotificationProvider.__mro__:
+        if hasattr(cls, "__abstractmethods__"):
+            abstract_methods.update(cls.__abstractmethods__)
+
+    # After the concrete class, there should be no remaining abstract methods
+    assert len(SlackNotificationProvider.__abstractmethods__) == 0, (
+        f"Unimplemented abstract methods: "
+        f"{SlackNotificationProvider.__abstractmethods__}"
+    )
+
+
+def test_expected_methods_exist():
+    """Verify that all required methods are present on the class."""
+    required_methods = [
+        "initialize",
+        "shutdown",
+        "health_check",
+        "send_notification",
+        "send_batch",
+    ]
+    for method in required_methods:
+        assert hasattr(SlackNotificationProvider, method), (
+            f"Missing method: {method}"
+        )
+        assert callable(getattr(SlackNotificationProvider, method))
+
+
+@pytest.mark.asyncio
+async def test_provider_lifecycle():
+    """Test the full initialize -> use -> shutdown lifecycle."""
+    provider = SlackNotificationProvider(
+        bot_token="xoxb-test",
+        default_channel="#test"
+    )
+
+    # Before initialization
+    assert provider.health_check() is False
+
+    # After initialization
+    await provider.initialize({})
+    assert provider.health_check() is True
+
+    # After shutdown
+    await provider.shutdown()
+    assert provider.health_check() is False
+```
+
+### Mocking External Services
+
+For providers that wrap HTTP APIs, you can use `aioresponses` to mock HTTP responses at the `aiohttp` level. This is more realistic than mocking the `post` method directly because it exercises the full request construction path:
+
+```python
+"""Unit tests using aioresponses for HTTP mocking."""
+
+import pytest
+from aioresponses import aioresponses
+
+from providers.slack_provider import SlackNotificationProvider
+
+
+@pytest.fixture
+async def provider():
+    """Create and initialize a provider for HTTP-level mocking."""
+    p = SlackNotificationProvider(
+        bot_token="xoxb-test-token",
+        default_channel="#test"
+    )
+    await p.initialize({})
+    yield p
+    await p.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_send_notification_with_aioresponses(provider):
+    """Test send_notification with realistic HTTP mocking."""
+    with aioresponses() as mocked:
+        mocked.post(
+            "https://slack.com/api/chat.postMessage",
+            payload={"ok": True}
+        )
+
+        result = await provider.send_notification(
+            "#test", "Hello from mocked HTTP"
+        )
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_send_notification_server_error(provider):
+    """Test send_notification handles 500 errors from Slack."""
+    with aioresponses() as mocked:
+        mocked.post(
+            "https://slack.com/api/chat.postMessage",
+            status=500
+        )
+        # Also mock retries
+        mocked.post(
+            "https://slack.com/api/chat.postMessage",
+            payload={"ok": True}
+        )
+
+        import asyncio
+        from unittest.mock import patch
+
+        with patch.object(asyncio, "sleep"):
+            result = await provider.send_notification(
+                "#test", "Retry test"
+            )
+        assert result is True
+```
+
+### Test Configuration Summary
+
+The recommended test configuration for provider plugins:
+
+| Test Type | Scope | Speed | Network | When to Run |
+|-----------|-------|-------|---------|-------------|
+| Contract tests | Interface compliance | Fast | No | Every commit |
+| Unit tests (mocked) | Internal logic | Fast | No | Every commit |
+| Unit tests (aioresponses) | HTTP handling | Fast | No | Every commit |
+| Integration tests | Real API | Slow | Yes | Pre-merge / CI |
+| End-to-end tests | Full pipeline | Slow | Yes | Release |
+
+### Checklist for New Provider Plugins
+
+Before submitting a custom provider, verify that it passes all of the following checks:
+
+- [ ] Inherits from the correct abstract interface (e.g., `NotificationProvider`)
+- [ ] Implements all abstract methods from both the interface and `BaseProvider`
+- [ ] `initialize()` creates resources, `shutdown()` releases them, `health_check()` reports status
+- [ ] All external network calls are wrapped in try/except with appropriate error logging
+- [ ] Retry logic handles transient failures with exponential backoff
+- [ ] Rate limiting responses (HTTP 429) are respected
+- [ ] The provider can be configured entirely through `swe_team.yaml` without code changes
+- [ ] Secrets are read from environment variables, never hardcoded
+- [ ] Unit tests cover success, error, rate-limiting, and network-failure scenarios
+- [ ] Contract tests confirm all abstract methods are implemented
+- [ ] The provider is registered in `swe_team.yaml` with a unique name under the correct interface type

--- a/src/content/docs/security-rbac.md
+++ b/src/content/docs/security-rbac.md
@@ -1,0 +1,264 @@
+---
+title: Security and RBAC
+description: Bot containment, credential scoping, RBAC middleware, circuit breakers, governance controls, and audit trails
+section: Advanced
+order: 3
+---
+
+# Security and RBAC
+
+SWE-Squad operates autonomous agents that can read code, write patches, and create pull requests. Because these agents have real write access to production repositories, security boundaries and access controls are critical. This guide covers every layer of the security model: bot containment, credential scoping, role-based access control, circuit breakers, governance controls, and audit trails.
+
+## Overview
+
+The SWE-Squad security architecture is built on the principle of least privilege. Every component -- from the container runtime to the API tokens to the agent decorators -- is designed to minimize the blast radius of a misbehaving or compromised agent. The system enforces isolation at four levels:
+
+1. **Runtime isolation** -- Agents run in sandboxed containers or VMs, never on bare metal.
+2. **Credential isolation** -- Each team uses its own set of API keys and tokens.
+3. **Permission isolation** -- RBAC middleware ensures agents and users can only perform actions their role permits.
+4. **Operational isolation** -- Governance controls and circuit breakers prevent runaway or cascading failures.
+
+Together, these layers ensure that even if a single agent is compromised or produces an incorrect result, the damage is contained and auditable.
+
+## Bot Containment Policy
+
+All SWE-Squad agents must run in a sandboxed VM or container environment. Never run bots directly on production infrastructure. The containment policy is enforced by the `SWE_DOCKER_ENABLED` environment variable and the `@require_sandbox` decorator.
+
+**Key policies:**
+
+- **Run in Docker containers or VMs only.** Agent tool calls (file reads, file writes, shell execution) are executed inside a sandboxed runtime when `SWE_DOCKER_ENABLED=true`.
+- **No direct access to production databases.** Agents interact with production state exclusively through the Supabase API, which enforces row-level security policies.
+- **Network egress restricted to required APIs.** The container firewall allows outbound connections only to GitHub, Anthropic, and Supabase endpoints. All other egress is denied.
+- **Filesystem access scoped to the repository checkout.** Agents can only read and write files within the cloned repository directory. Access to host filesystem paths outside the checkout is blocked.
+- **Container resource limits prevent runaway processes.** CPU and memory limits are applied to every agent container. A misbehaving agent that consumes excessive resources is killed by the runtime before it impacts other agents or the host.
+
+To enable container sandboxing, set the environment variable:
+
+```bash
+SWE_DOCKER_ENABLED=true
+```
+
+This is the recommended setting for all production deployments. In development, you may set `SWE_DOCKER_ENABLED=false` for faster iteration, but be aware that agents will execute tool calls directly on the host.
+
+## Credential Scoping
+
+Each team uses its own set of credentials, preventing privilege escalation across teams. A compromised token for one team cannot be used to access another team's repositories, tickets, or billing.
+
+### Credential Scoping Table
+
+| Credential | Scope | Purpose |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Per team | LLM inference billing isolation. Each team pays for its own model usage. |
+| `GITHUB_TOKEN` | Per team (dedicated bot account) | Repository access and PR creation. Scopes limited to `repo` and `read:org`. |
+| `SUPABASE_ANON_KEY` | Shared across teams | Client-side API access. Row-level security (RLS) policies enforce ticket isolation per `SWE_TEAM_ID`. |
+| `SWE_WEBHOOK_SECRET` | Per team | Webhook payload verification. Prevents cross-team webhook injection. |
+
+### Token Management
+
+- **Tokens are stored in `.env` files, never committed to version control.** Add `.env` to your `.gitignore` before the first commit.
+- **GitHub token scopes should be minimal.** Only `repo` (for branch creation and PR management) and `read:org` (for team membership lookups) are required. Do not grant `admin:org`, `delete_repo`, or other broad scopes.
+- **Rotate credentials on a regular schedule.** Set a calendar reminder to rotate API keys and tokens at least every 90 days. When a team member leaves, revoke their tokens immediately.
+
+### Example `.env` per Team
+
+```bash
+# Team: backend-api
+ANTHROPIC_API_KEY=sk-ant-api03-...
+GITHUB_TOKEN=ghp_backendBot...
+SUPABASE_URL=https://shared.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOi...
+SWE_TEAM_ID=backend-api-team
+SWE_WEBHOOK_SECRET=whsec_backend_...
+```
+
+```bash
+# Team: frontend-web
+ANTHROPIC_API_KEY=sk-ant-api03-...
+GITHUB_TOKEN=ghp_frontendBot...
+SUPABASE_URL=https://shared.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOi...
+SWE_TEAM_ID=frontend-web-team
+SWE_WEBHOOK_SECRET=whsec_frontend_...
+```
+
+Both teams share the same `SUPABASE_URL` and `SUPABASE_ANON_KEY`, but RLS policies ensure that Team A cannot read or modify Team B's tickets.
+
+## RBAC Middleware
+
+SWE-Squad enforces role-based access control through middleware decorators in the `swe_team.rbac` module. These decorators check the calling agent or user's permission level before allowing execution.
+
+### Roles
+
+| Role | Permissions |
+|---|---|
+| **Viewer** | View incidents and reports |
+| **Operator** | View + Apply fixes + Manage alerts |
+| **Admin** | Full access + Configuration + Deploy |
+| **Auditor** | View all + Audit logs + Compliance |
+
+Roles are hierarchical: Admin inherits all Operator and Viewer permissions. Auditor is a cross-cutting role that can read all data and audit logs but cannot modify incidents or deploy fixes.
+
+### Decorators
+
+- **`@require_permission(role)`** -- Checks that the caller has at least the required permission level. Raises `PermissionDenied` if the check fails.
+- **`@require_sandbox`** -- Enforces that the operation must run within a sandboxed environment. Raises `SandboxRequired` if `SWE_DOCKER_ENABLED` is `false` or the sandbox check fails.
+
+### Code Example
+
+```python
+from swe_team.rbac import require_permission, require_sandbox
+
+@require_permission("admin")
+@require_sandbox
+async def deploy_fix(ticket_id: str, patch: str):
+    """Deploy a validated fix -- requires admin role and sandbox environment."""
+    ...
+
+@require_permission("operator")
+async def apply_fix(ticket_id: str):
+    """Apply a generated fix -- operators and above."""
+    ...
+```
+
+Decorators are composable. Stack `@require_sandbox` with `@require_permission` to enforce both constraints on the same function.
+
+## Circuit Breaker
+
+The circuit breaker pattern prevents cascading failures when an upstream service or agent operation becomes unreliable. SWE-Squad implements circuit breakers around all external calls: API requests, model inference, and tool execution.
+
+### How It Works
+
+1. **Closed state (normal operation).** All calls pass through. The breaker counts consecutive failures.
+2. **Open state (tripped).** When the failure count reaches the configured threshold (default: 5), the circuit opens. All subsequent calls are short-circuited and return immediately with an error, preventing wasted time and resources.
+3. **Half-open state (probing).** After a cooldown period (default: 60 seconds), the circuit transitions to half-open. A single test request is allowed through.
+4. **Recovery or re-trip.** If the test request succeeds, the circuit closes and normal operation resumes. If the test request fails, the circuit reopens and the cooldown restarts.
+
+### State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Closed
+    Closed --> Open: Failure threshold reached
+    Open --> HalfOpen: Cooldown expires
+    HalfOpen --> Closed: Test request succeeds
+    HalfOpen --> Open: Test request fails
+```
+
+### Configuration
+
+Add the `circuit_breaker` section to your `swe_team.yaml`:
+
+```yaml
+circuit_breaker:
+  failure_threshold: 5
+  cooldown_seconds: 60
+  half_open_max_calls: 1
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `circuit_breaker.failure_threshold` | number | `5` | Consecutive failures required to trip the circuit. |
+| `circuit_breaker.cooldown_seconds` | number | `60` | Seconds to wait in the open state before transitioning to half-open. |
+| `circuit_breaker.half_open_max_calls` | number | `1` | Number of test requests allowed in the half-open state. |
+
+Circuit breakers are applied per service. If the GitHub API trips its breaker, the Anthropic API and Supabase API continue operating normally. This isolates failures to the affected dependency.
+
+## Governance Controls
+
+The `governance` section in `swe_team.yaml` controls the guardrails that determine whether a fix is allowed to merge, requires human review, or is blocked outright. These controls are the last line of defense before code reaches production.
+
+### Governance Configuration Table
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `governance.require_approval` | boolean | `false` | Whether human approval is required before merging fixes. |
+| `governance.auto_merge` | boolean | `false` | Whether to automatically merge fixes that pass the stability gate. |
+| `governance.stability_gate` | boolean | `true` | Enable or disable the full validation suite (tests, lint, type check, security scan). |
+| `governance.test_threshold` | number | `0.8` | Minimum test pass rate (0.0--1.0) required to allow merge. |
+| `governance.max_file_changes` | number | `20` | Maximum number of files a fix can modify. PRs exceeding this are blocked. |
+| `governance.max_line_changes` | number | `500` | Maximum number of lines a fix can change. PRs exceeding this are blocked. |
+| `governance.rejection_limit` | number | `3` | Number of review rejections before the incident is escalated to a human. |
+
+### Development vs. Production
+
+Governance settings should differ between environments. Development favors speed and iteration; production favors safety and control.
+
+**Development configuration:**
+
+```yaml
+governance:
+  require_approval: false
+  auto_merge: true
+  stability_gate: true
+  test_threshold: 0.7
+  max_file_changes: 30
+  max_line_changes: 1000
+  rejection_limit: 5
+```
+
+**Production configuration:**
+
+```yaml
+governance:
+  require_approval: true
+  auto_merge: false
+  stability_gate: true
+  test_threshold: 0.95
+  max_file_changes: 10
+  max_line_changes: 200
+  rejection_limit: 2
+```
+
+In production, every fix requires explicit human approval (`require_approval: true`), auto-merge is disabled, the test threshold is set to 95%, and the change limits are tight. A fix that modifies more than 10 files or 200 lines is automatically blocked for manual review.
+
+## Audit Trail via Supabase Events
+
+Every significant action in SWE-Squad is logged as an event in the Supabase `audit_events` table. This provides a complete, tamper-evident record of what the system did, when, and on whose behalf.
+
+### Logged Event Types
+
+- **Ticket state transitions** -- New, Triaged, Investigating, In Development, In Review, Deployed
+- **Fix submissions and review outcomes** -- Patch generated, review passed, review rejected
+- **Governance decisions** -- Approvals, rejections, escalations to human reviewers
+- **RBAC permission checks** -- Granted and denied permission checks, with the requesting role and target operation
+- **Circuit breaker state changes** -- Circuit opened, closed, or transitioned to half-open
+- **Agent actions** -- Tool calls (file reads, file writes, shell execution), PR creation, branch operations
+
+### Querying Audit Events
+
+Events are queryable via the Supabase Dashboard or the Supabase REST API. The following SQL query retrieves the last 7 days of audit events for a specific team:
+
+```sql
+SELECT event_type, agent_id, ticket_id, metadata, created_at
+FROM audit_events
+WHERE team_id = 'backend-api-team'
+  AND created_at > NOW() - INTERVAL '7 days'
+ORDER BY created_at DESC;
+```
+
+To filter for a specific event type, add a condition:
+
+```sql
+SELECT event_type, agent_id, ticket_id, metadata, created_at
+FROM audit_events
+WHERE team_id = 'backend-api-team'
+  AND event_type = 'permission_denied'
+  AND created_at > NOW() - INTERVAL '7 days'
+ORDER BY created_at DESC;
+```
+
+Audit events are retained indefinitely by default. Set a retention policy via Supabase RLS or a scheduled function if your organization requires data lifecycle management.
+
+## Best Practices
+
+Follow this checklist to maintain a secure SWE-Squad deployment:
+
+- Always run agents in containers or VMs. Set `SWE_DOCKER_ENABLED=true` in production.
+- Use dedicated GitHub bot accounts per team. Never share bot tokens across teams.
+- Scope API keys to the minimum required permissions. Grant only `repo` and `read:org` scopes on GitHub tokens.
+- Enable governance controls in production. Set `require_approval: true` to enforce human review before merge.
+- Set `stability_gate: true` and a high `test_threshold` (0.9 or above) in production.
+- Use `max_file_changes` and `max_line_changes` to limit blast radius. Start with conservative limits and relax them only when justified.
+- Enable circuit breakers to prevent cascading failures. Tune `failure_threshold` and `cooldown_seconds` based on your upstream service reliability.
+- Regularly review audit logs in Supabase. Set up automated alerts for `permission_denied` and `circuit_open` events.
+- Rotate credentials on a regular schedule. Replace API keys and tokens at least every 90 days, and immediately after any team member with access leaves the organization.

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,0 +1,442 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Callout from '@components/Callout.astro';
+---
+
+<BaseLayout title="Pricing &amp; Support — SWE-Squad">
+  <div class="page">
+
+    <a href="/" class="back-link">&larr; Home</a>
+
+    <h1 class="page-title">Pricing &amp; Support</h1>
+    <p class="page-intro">
+      SWE-Squad is open source at heart. The complete platform is available under the MIT
+      license at no cost, with optional enterprise support for organizations that need
+      guaranteed response times, deployment assistance, and custom integrations.
+    </p>
+
+    <!-- Section 1: Pricing Tiers -->
+    <section class="section">
+      <h2>Choose Your Plan</h2>
+      <p>
+        Every feature, every integration, every provider — the open source version is the
+        complete product. Enterprise support adds dedicated assistance and custom
+        development on top of the same fully-featured platform.
+      </p>
+
+      <div class="pricing-grid">
+        <!-- Open Source Tier -->
+        <div class="pricing-card pricing-card--highlighted">
+          <div class="pricing-card__badge">Open Source</div>
+          <div class="pricing-card__header">
+            <h3 class="pricing-card__name">Community</h3>
+            <div class="pricing-card__price">Free forever</div>
+          </div>
+          <p class="pricing-card__description">
+            The complete SWE-Squad platform — not a limited version. Every feature is
+            included with no gates, no premium tiers, and no surprises.
+          </p>
+          <ul class="pricing-card__features">
+            <li>Full MIT-licensed codebase</li>
+            <li>All features included — no feature gating</li>
+            <li>Community support via GitHub Discussions</li>
+            <li>Self-hosted deployment</li>
+            <li>Access to all providers and integrations</li>
+            <li>Regular updates and patches</li>
+          </ul>
+          <a href="https://github.com/swe-squad/swe-squad" class="pricing-card__cta">
+            Get Started on GitHub
+          </a>
+        </div>
+
+        <!-- Enterprise Tier -->
+        <div class="pricing-card">
+          <div class="pricing-card__badge pricing-card__badge--enterprise">Enterprise</div>
+          <div class="pricing-card__header">
+            <h3 class="pricing-card__name">Enterprise Support</h3>
+            <div class="pricing-card__price">Contact us</div>
+          </div>
+          <p class="pricing-card__description">
+            Everything in the open source release, plus dedicated support and custom
+            services for organizations with production-critical requirements.
+          </p>
+          <ul class="pricing-card__features">
+            <li>Everything in Open Source, plus:</li>
+            <li>Priority support with guaranteed response times</li>
+            <li>Deployment assistance and architecture review</li>
+            <li>Custom provider development</li>
+            <li>SLA-backed uptime guarantees</li>
+            <li>Dedicated Slack channel</li>
+          </ul>
+          <a href="mailto:enterprise@swe-squad.dev" class="pricing-card__cta pricing-card__cta--secondary">
+            Contact Sales
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 2: No Feature Gating -->
+    <section class="section">
+      <h2>No Feature Gating</h2>
+      <Callout type="success" title="Open source IS the complete product">
+        <p>
+          SWE-Squad does not hold back features behind a paywall. The open source release
+          is the same codebase used by the core team — every provider, every integration,
+          every capability. There are no premium tiers for core functionality, no
+          artificial limits on incidents or teams, and no plans to change that.
+        </p>
+        <p>
+          Enterprise support exists to help organizations that need dedicated assistance,
+          not to unlock features. If you can self-host and self-support, you have the
+          complete product at zero cost.
+        </p>
+      </Callout>
+    </section>
+
+    <!-- Section 3: FAQ -->
+    <section class="section">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-list">
+        <div class="faq-item">
+          <h3 class="faq-item__question">Is the open source version really the complete product?</h3>
+          <p class="faq-item__answer">
+            Yes. The MIT-licensed repository contains every feature, provider integration,
+            and capability that SWE-Squad offers. There is no separate "enterprise edition"
+            with additional features. Enterprise support adds human assistance, not
+            software capabilities.
+          </p>
+        </div>
+        <div class="faq-item">
+          <h3 class="faq-item__question">How do I get started with self-hosted deployment?</h3>
+          <p class="faq-item__answer">
+            Clone the repository, run <code>npm install</code>, and start the development
+            server with <code>npm run dev</code>. The
+            <a href="/docs" class="link">documentation</a> covers full deployment
+            instructions, configuration options, and environment setup for production use.
+          </p>
+        </div>
+        <div class="faq-item">
+          <h3 class="faq-item__question">What does enterprise support include?</h3>
+          <p class="faq-item__answer">
+            Enterprise support provides priority response times for issues, hands-on
+            deployment assistance, architecture reviews for your specific infrastructure,
+            custom provider development for proprietary systems, SLA-backed uptime
+            guarantees, and a dedicated Slack channel for real-time communication with
+            the core team.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 4: CTA -->
+    <section class="section cta-section">
+      <Callout type="info" title="Ready to get started?">
+        <p>
+          Explore the <a href="/docs" class="link">documentation</a> to set up SWE-Squad
+          for your team, or <a href="mailto:enterprise@swe-squad.dev" class="link">contact
+          our team</a> to discuss enterprise support options for your organization.
+        </p>
+      </Callout>
+    </section>
+
+  </div>
+</BaseLayout>
+
+<style>
+  :root {
+    --color-bg: #ffffff;
+    --color-bg-sidebar: #f9fafb;
+    --color-text-primary: #1a1a2e;
+    --color-text-secondary: #4a4a6a;
+    --color-text-tertiary: #9ca3af;
+    --color-accent: #3b82f6;
+    --color-border: #e5e7eb;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    color: var(--color-text-primary);
+    background-color: var(--color-bg);
+    line-height: 1.6;
+  }
+
+  .page {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    color: var(--color-accent);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    margin-bottom: 1.5rem;
+    transition: color 0.15s;
+  }
+
+  .back-link:hover {
+    color: #2563eb;
+    text-decoration: underline;
+  }
+
+  .page-title {
+    font-size: 2.25rem;
+    font-weight: 800;
+    margin: 0 0 0.5rem;
+    color: var(--color-text-primary);
+  }
+
+  .page-intro {
+    font-size: 1.0625rem;
+    color: var(--color-text-secondary);
+    margin: 0 0 3rem;
+    line-height: 1.7;
+  }
+
+  /* ---- Sections ---- */
+  .section {
+    margin-bottom: 4rem;
+  }
+
+  .section h2 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin: 0 0 0.75rem;
+    color: var(--color-accent);
+  }
+
+  .section p {
+    font-size: 1rem;
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+    margin: 0 0 1rem;
+  }
+
+  .section code {
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.875em;
+    background: var(--color-bg-sidebar);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.125em 0.375em;
+  }
+
+  .link {
+    color: var(--color-accent);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .link:hover {
+    text-decoration: underline;
+    color: #2563eb;
+  }
+
+  /* ---- Pricing Grid ---- */
+  .pricing-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+  }
+
+  /* ---- Pricing Card ---- */
+  .pricing-card {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    position: relative;
+  }
+
+  .pricing-card--highlighted {
+    border-color: var(--color-accent);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.12);
+  }
+
+  .pricing-card__badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.25rem 0.625rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.1);
+    color: var(--color-accent);
+    margin-bottom: 1rem;
+    align-self: flex-start;
+  }
+
+  .pricing-card__badge--enterprise {
+    background: rgba(107, 114, 128, 0.1);
+    color: #6b7280;
+  }
+
+  .pricing-card__header {
+    margin-bottom: 1rem;
+  }
+
+  .pricing-card__name {
+    font-size: 1.375rem;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    margin: 0 0 0.375rem;
+  }
+
+  .pricing-card__price {
+    font-size: 1.75rem;
+    font-weight: 800;
+    color: var(--color-accent);
+  }
+
+  .pricing-card__description {
+    font-size: 0.9375rem;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+    margin: 0 0 1.5rem;
+  }
+
+  /* ---- Feature Lists ---- */
+  .pricing-card__features {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 2rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+
+  .pricing-card__features li {
+    font-size: 0.9375rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    padding-left: 1.5rem;
+    position: relative;
+  }
+
+  .pricing-card__features li::before {
+    content: '\2713';
+    position: absolute;
+    left: 0;
+    color: #16a34a;
+    font-weight: 700;
+    font-size: 0.875rem;
+  }
+
+  /* ---- CTA Buttons ---- */
+  .pricing-card__cta {
+    display: inline-block;
+    text-align: center;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    background: var(--color-accent);
+    color: #ffffff;
+    transition: background 0.15s, box-shadow 0.15s;
+  }
+
+  .pricing-card__cta:hover {
+    background: #2563eb;
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.25);
+  }
+
+  .pricing-card__cta--secondary {
+    background: var(--color-bg);
+    color: var(--color-accent);
+    border: 1px solid var(--color-accent);
+  }
+
+  .pricing-card__cta--secondary:hover {
+    background: rgba(59, 130, 246, 0.06);
+    color: #2563eb;
+    border-color: #2563eb;
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.12);
+  }
+
+  /* ---- FAQ ---- */
+  .faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+
+  .faq-item {
+    background: var(--color-bg-sidebar);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+  }
+
+  .faq-item__question {
+    font-size: 1.0625rem;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    margin: 0 0 0.5rem;
+  }
+
+  .faq-item__answer {
+    font-size: 0.9375rem;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  /* ---- CTA Section ---- */
+  .cta-section {
+    margin-top: 2rem;
+  }
+
+  .cta-section :global(a) {
+    color: var(--color-accent);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .cta-section :global(a:hover) {
+    text-decoration: underline;
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 768px) {
+    .page {
+      padding: 1.5rem 1rem 3rem;
+    }
+
+    .page-title {
+      font-size: 1.75rem;
+    }
+
+    .section h2 {
+      font-size: 1.375rem;
+    }
+
+    .pricing-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .pricing-card {
+      padding: 1.5rem;
+    }
+
+    .pricing-card__price {
+      font-size: 1.5rem;
+    }
+  }
+</style>

--- a/tests/unit/docs-navigation.test.ts
+++ b/tests/unit/docs-navigation.test.ts
@@ -68,13 +68,15 @@ const sampleDocs: DocEntry[] = [
   { slug: 'architecture', title: 'Architecture', section: 'Core Concepts', order: 1 },
   { slug: 'agents', title: 'Agents', section: 'Core Concepts', order: 2 },
   { slug: 'api-reference', title: 'API Reference', section: 'API', order: 1 },
+  { slug: 'configuration-reference', title: 'Configuration Reference', section: 'Reference', order: 1 },
+  { slug: 'provider-plugin-guide', title: 'Provider Plugin Development Guide', section: 'Advanced', order: 1 },
 ];
 
 describe('Sidebar sections', () => {
   it('groups docs by section', () => {
     const sections = buildSidebarSections(sampleDocs);
-    expect(sections).toHaveLength(3);
-    expect(sections.map((s) => s.name)).toEqual(['API', 'Core Concepts', 'Getting Started']);
+    expect(sections).toHaveLength(5);
+    expect(sections.map((s) => s.name)).toEqual(['Advanced', 'API', 'Core Concepts', 'Getting Started', 'Reference']);
   });
 
   it('sorts items within each section by order', () => {
@@ -102,14 +104,14 @@ describe('Prev/Next navigation', () => {
   });
 
   it('returns null prev for the first doc in sorted order', () => {
-    const { prev, next } = getPrevNext(sampleDocs, 'api-reference');
+    const { prev, next } = getPrevNext(sampleDocs, 'provider-plugin-guide');
     expect(prev).toBeNull();
-    expect(next?.slug).toBe('architecture');
+    expect(next?.slug).toBe('api-reference');
   });
 
   it('returns null next for the last doc in sorted order', () => {
-    const { prev, next } = getPrevNext(sampleDocs, 'running');
-    expect(prev?.slug).toBe('configuration');
+    const { prev, next } = getPrevNext(sampleDocs, 'configuration-reference');
+    expect(prev?.slug).toBe('running');
     expect(next).toBeNull();
   });
 

--- a/tests/unit/pricing-page.test.ts
+++ b/tests/unit/pricing-page.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const pagePath = resolve(__dirname, '../../src/pages/pricing.astro');
+const pageContent = readFileSync(pagePath, 'utf-8');
+
+describe('Pricing page', () => {
+  it('file exists and is not empty', () => {
+    expect(pageContent).toBeTruthy();
+    expect(pageContent.length).toBeGreaterThan(0);
+  });
+
+  it('imports BaseLayout and Callout components', () => {
+    expect(pageContent).toContain("import BaseLayout from '@layouts/BaseLayout.astro'");
+    expect(pageContent).toContain("import Callout from '@components/Callout.astro'");
+  });
+
+  it('uses BaseLayout with correct title', () => {
+    expect(pageContent).toContain('<BaseLayout title="Pricing &amp; Support — SWE-Squad">');
+  });
+
+  it('contains back link and page header', () => {
+    expect(pageContent).toContain('class="back-link"');
+    expect(pageContent).toContain('class="page-title"');
+    expect(pageContent).toContain('Pricing &amp; Support');
+    expect(pageContent).toContain('class="page-intro"');
+  });
+
+  it('contains Open Source tier with pricing and features', () => {
+    expect(pageContent).toContain('Free forever');
+    expect(pageContent).toContain('Full MIT-licensed codebase');
+    expect(pageContent).toContain('All features included — no feature gating');
+    expect(pageContent).toContain('Community support via GitHub Discussions');
+    expect(pageContent).toContain('Self-hosted deployment');
+    expect(pageContent).toContain('Access to all providers and integrations');
+    expect(pageContent).toContain('Regular updates and patches');
+  });
+
+  it('contains Enterprise tier with pricing and features', () => {
+    expect(pageContent).toContain('Contact us');
+    expect(pageContent).toContain('Priority support with guaranteed response times');
+    expect(pageContent).toContain('Deployment assistance and architecture review');
+    expect(pageContent).toContain('Custom provider development');
+    expect(pageContent).toContain('SLA-backed uptime guarantees');
+    expect(pageContent).toContain('Dedicated Slack channel');
+  });
+
+  it('has GitHub CTA link for open source tier', () => {
+    expect(pageContent).toContain('href="https://github.com/swe-squad/swe-squad"');
+    expect(pageContent).toContain('Get Started on GitHub');
+  });
+
+  it('has contact email for enterprise tier', () => {
+    expect(pageContent).toContain('href="mailto:enterprise@swe-squad.dev"');
+    expect(pageContent).toContain('Contact Sales');
+  });
+
+  it('has no-feature-gating callout with success type', () => {
+    expect(pageContent).toContain('<Callout type="success"');
+    expect(pageContent).toContain('No Feature Gating');
+    expect(pageContent).toContain('paywall');
+  });
+
+  it('has FAQ section with questions', () => {
+    expect(pageContent).toContain('Frequently Asked Questions');
+    expect(pageContent).toContain('Is the open source version really the complete product?');
+    expect(pageContent).toContain('How do I get started with self-hosted deployment?');
+    expect(pageContent).toContain('What does enterprise support include?');
+  });
+
+  it('has bottom CTA section with info callout', () => {
+    expect(pageContent).toContain('<Callout type="info"');
+    expect(pageContent).toContain('Ready to get started?');
+    expect(pageContent).toContain('href="/docs"');
+  });
+
+  it('includes CSS custom properties matching project pattern', () => {
+    expect(pageContent).toContain('--color-bg: #ffffff');
+    expect(pageContent).toContain('--color-bg-sidebar: #f9fafb');
+    expect(pageContent).toContain('--color-text-primary: #1a1a2e');
+    expect(pageContent).toContain('--color-text-secondary: #4a4a6a');
+    expect(pageContent).toContain('--color-accent: #3b82f6');
+    expect(pageContent).toContain('--color-border: #e5e7eb');
+  });
+
+  it('uses responsive breakpoint at 768px', () => {
+    expect(pageContent).toContain('@media (max-width: 768px)');
+  });
+
+  it('uses two-column pricing grid layout', () => {
+    expect(pageContent).toContain('grid-template-columns: 1fr 1fr');
+    expect(pageContent).toContain('class="pricing-grid"');
+  });
+});

--- a/tests/unit/search-dialog.test.ts
+++ b/tests/unit/search-dialog.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+
+// --- Logic extracted from SearchDialog for testability ---
+
+function shouldTriggerSearch(e: { metaKey: boolean; ctrlKey: boolean; key: string }): boolean {
+  return (e.metaKey || e.ctrlKey) && e.key === 'k';
+}
+
+function shouldCloseOnEscape(e: { key: string }): boolean {
+  return e.key === 'Escape';
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+interface SearchResult {
+  url: string;
+  title: string;
+  excerpt: string;
+}
+
+function renderResults(results: SearchResult[], query: string): string {
+  if (!query.trim()) {
+    return '<p class="search-empty">Type to search documentation and blog posts</p>';
+  }
+
+  if (results.length === 0) {
+    return `<p class="search-no-results">No results for "${escapeHtml(query)}"</p>`;
+  }
+
+  return results
+    .slice(0, 8)
+    .map(
+      (r) =>
+        `<a href="${r.url}" class="search-result-item"><p class="search-result-title">${escapeHtml(r.title)}</p><p class="search-result-excerpt">${r.excerpt}</p></a>`
+    )
+    .join('');
+}
+
+// --- Tests ---
+
+describe('Search keyboard shortcuts', () => {
+  it('triggers on Cmd+K (macOS)', () => {
+    expect(shouldTriggerSearch({ metaKey: true, ctrlKey: false, key: 'k' })).toBe(true);
+  });
+
+  it('triggers on Ctrl+K (Windows/Linux)', () => {
+    expect(shouldTriggerSearch({ metaKey: false, ctrlKey: true, key: 'k' })).toBe(true);
+  });
+
+  it('does not trigger on plain K', () => {
+    expect(shouldTriggerSearch({ metaKey: false, ctrlKey: false, key: 'k' })).toBe(false);
+  });
+
+  it('does not trigger on Cmd+other', () => {
+    expect(shouldTriggerSearch({ metaKey: true, ctrlKey: false, key: 'j' })).toBe(false);
+  });
+
+  it('closes on Escape', () => {
+    expect(shouldCloseOnEscape({ key: 'Escape' })).toBe(true);
+  });
+
+  it('does not close on other keys', () => {
+    expect(shouldCloseOnEscape({ key: 'Enter' })).toBe(false);
+  });
+});
+
+describe('Search result rendering', () => {
+  const sampleResults: SearchResult[] = [
+    { url: '/docs/getting-started', title: 'Getting Started', excerpt: 'Learn how to install and configure...' },
+    { url: '/docs/configuration', title: 'Configuration', excerpt: 'All available <mark>configuration</mark> options...' },
+    { url: '/blog/deploy', title: 'Deploy Guide', excerpt: 'How to deploy your application...' },
+  ];
+
+  it('renders up to 8 results', () => {
+    const html = renderResults(sampleResults, 'config');
+    const count = (html.match(/class="search-result-item"/g) || []).length;
+    expect(count).toBe(3);
+  });
+
+  it('truncates to 8 results when more are returned', () => {
+    const many = Array.from({ length: 15 }, (_, i) => ({
+      url: `/docs/page-${i}`,
+      title: `Page ${i}`,
+      excerpt: `Excerpt ${i}`,
+    }));
+    const html = renderResults(many, 'page');
+    const count = (html.match(/class="search-result-item"/g) || []).length;
+    expect(count).toBe(8);
+  });
+
+  it('shows empty state when query is empty', () => {
+    const html = renderResults([], '');
+    expect(html).toContain('search-empty');
+  });
+
+  it('shows no-results state when no results match', () => {
+    const html = renderResults([], 'nonexistent');
+    expect(html).toContain('No results');
+    expect(html).toContain('nonexistent');
+  });
+
+  it('escapes HTML in titles to prevent XSS', () => {
+    const malicious: SearchResult[] = [
+      { url: '/docs/test', title: '<script>alert("xss")</script>', excerpt: 'safe' },
+    ];
+    const html = renderResults(malicious, 'test');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('HTML escaping', () => {
+  it('escapes angle brackets', () => {
+    expect(escapeHtml('<div>')).toBe('&lt;div&gt;');
+  });
+
+  it('escapes ampersands', () => {
+    expect(escapeHtml('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes quotes', () => {
+    expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Multi-Team Setup guide (team IDs, GitHub bots, shared Supabase, ticket isolation, cross-team memory)
- Add Security and RBAC guide (bot containment, credential scoping, RBAC middleware, circuit breaker, governance, audit trail)
- Closes #25

## Test plan
- [x] Both docs render correctly in Astro content collection
- [x] Frontmatter follows standard pattern (title, description, section, order)
- [x] Mermaid diagrams included for multi-team architecture and circuit breaker states
- [x] Code examples match existing configuration-reference.md patterns
- [x] No emojis used; tone matches existing docs